### PR TITLE
Appcompat spinner

### DIFF
--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/Cirrious.MvvmCross.Droid.Support.AppCompat.csproj
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/Cirrious.MvvmCross.Droid.Support.AppCompat.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MvxActionBarDrawerToggle.cs" />
+    <Compile Include="MvxAppCompatSetupHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvxCachingFragmentActivityCompat.cs" />
     <Compile Include="MvxActivityCompat.cs" />

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/Cirrious.MvvmCross.Droid.Support.AppCompat.csproj
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/Cirrious.MvvmCross.Droid.Support.AppCompat.csproj
@@ -75,6 +75,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvxCachingFragmentActivityCompat.cs" />
     <Compile Include="MvxActivityCompat.cs" />
+    <Compile Include="Target\MvxAppCompatSpinnerSelectedItemBinding.cs" />
+    <Compile Include="Widget\MvxAppCompatSpinner.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/Cirrious.MvvmCross.Droid.Support.AppCompat.csproj
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/Cirrious.MvvmCross.Droid.Support.AppCompat.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MvxActionBarDrawerToggle.cs" />
+    <Compile Include="MvxAppCompatActivityHelper.cs" />
     <Compile Include="MvxAppCompatSetupHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvxCachingFragmentActivityCompat.cs" />

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
@@ -5,12 +5,14 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.OS;
 using Android.Runtime;
 using Android.Support.V7.App;
 using Android.Support.V7.Widget;
+using Android.Util;
 using Android.Views;
 using Cirrious.MvvmCross.Droid.Views;
 using Java.Lang;
@@ -118,6 +120,12 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
         public void InvalidateOptionsMenu()
         {
             CompatDelegate.InvalidateOptionsMenu();
+        }
+
+        public override View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
+        {
+            View view = MvxAppCompatActivityHelper.OnCreateView(parent, name, context, attrs);
+            return view ?? base.OnCreateView(parent, name, context, attrs);
         }
     }
 }

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxAppCompatActivityHelper.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxAppCompatActivityHelper.cs
@@ -1,0 +1,21 @@
+using Android.Content;
+using Android.Util;
+using Android.Views;
+using Cirrious.MvvmCross.Droid.Support.AppCompat.Widget;
+
+namespace Cirrious.MvvmCross.Droid.Support.AppCompat
+{
+    public static class MvxAppCompatActivityHelper
+    {
+        public static View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
+        {
+            // Swap our AppCompat Views
+            if (name == "MvxSpinner")
+            {
+                return new MvxAppCompatSpinner(context, attrs);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxAppCompatSetupHelper.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxAppCompatSetupHelper.cs
@@ -1,0 +1,15 @@
+using Cirrious.MvvmCross.Binding.Bindings.Target.Construction;
+using Cirrious.MvvmCross.Droid.Support.AppCompat.Target;
+using Cirrious.MvvmCross.Droid.Support.AppCompat.Widget;
+
+namespace Cirrious.MvvmCross.Droid.Support.AppCompat
+{
+    public static class MvxAppCompatSetupHelper
+    {
+        public static void FillTargetFactories(IMvxTargetBindingFactoryRegistry registry)
+        {
+            registry.RegisterCustomBindingFactory<MvxAppCompatSpinner>("SelectedItem",
+                spinner => new MvxAppCompatSpinnerSelectedItemBinding(spinner));
+        }
+    }
+}

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentActivityCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentActivityCompat.cs
@@ -5,12 +5,14 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
+using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.OS;
 using Android.Runtime;
 using Android.Support.V7.App;
 using Android.Support.V7.Widget;
+using Android.Util;
 using Android.Views;
 using Cirrious.MvvmCross.Droid.Fragging;
 using Java.Lang;
@@ -118,6 +120,12 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
         public void InvalidateOptionsMenu()
         {
             CompatDelegate.InvalidateOptionsMenu();
+        }
+
+        public override View OnCreateView(View parent, string name, Context context, IAttributeSet attrs)
+        {
+            View view = MvxAppCompatActivityHelper.OnCreateView(parent, name, context, attrs);
+            return view ?? base.OnCreateView(parent, name, context, attrs);
         }
     }
 }

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/Target/MvxAppCompatSpinnerSelectedItemBinding.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/Target/MvxAppCompatSpinnerSelectedItemBinding.cs
@@ -1,0 +1,108 @@
+using System;
+using Android.Widget;
+using Cirrious.CrossCore.Platform;
+using Cirrious.MvvmCross.Binding;
+using Cirrious.MvvmCross.Binding.Droid.Target;
+using Cirrious.MvvmCross.Droid.Support.AppCompat.Widget;
+
+namespace Cirrious.MvvmCross.Droid.Support.AppCompat.Target
+{
+    public class MvxAppCompatSpinnerSelectedItemBinding
+        : MvxAndroidTargetBinding
+    {
+        protected MvxAppCompatSpinner Spinner
+        {
+            get { return (MvxAppCompatSpinner)Target; }
+        }
+
+        private object _currentValue;
+        private bool _subscribed;
+
+        public MvxAppCompatSpinnerSelectedItemBinding(MvxAppCompatSpinner spinner)
+            : base(spinner) {}
+
+        private void SpinnerItemSelected(object sender, AdapterView.ItemSelectedEventArgs e)
+        {
+            var spinner = this.Spinner;
+            if (spinner == null)
+                return;
+
+            var newValue = spinner.Adapter.GetRawItem(e.Position);
+
+            bool changed;
+            if (newValue == null)
+            {
+                changed = (this._currentValue != null);
+            }
+            else
+            {
+                changed = !(newValue.Equals(this._currentValue));
+            }
+
+            if (!changed)
+            {
+                return;
+            }
+
+            this._currentValue = newValue;
+            FireValueChanged(newValue);
+        }
+
+        protected override void SetValueImpl(object target, object value)
+        {
+            var spinner = (MvxAppCompatSpinner)target;
+
+            if (value == null)
+            {
+                MvxBindingTrace.Warning("Null values not permitted in spinner SelectedItem binding currently");
+                return;
+            }
+
+            if (!value.Equals(this._currentValue))
+            {
+                var index = spinner.Adapter.GetPosition(value);
+                if (index < 0)
+                {
+                    MvxBindingTrace.Trace(MvxTraceLevel.Warning, "Value not found for spinner {0}", value.ToString());
+                    return;
+                }
+                this._currentValue = value;
+                spinner.SetSelection(index);
+            }
+        }
+
+        public override MvxBindingMode DefaultMode
+        {
+            get { return MvxBindingMode.TwoWay; }
+        }
+
+        public override void SubscribeToEvents()
+        {
+            var spinner = this.Spinner;
+            if (spinner == null)
+                return;
+
+            spinner.ItemSelected += this.SpinnerItemSelected;
+            this._subscribed = true;
+        }
+
+        public override Type TargetType
+        {
+            get { return typeof(object); }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                var spinner = this.Spinner;
+                if (spinner != null && this._subscribed)
+                {
+                    spinner.ItemSelected -= this.SpinnerItemSelected;
+                    this._subscribed = false;
+                }
+            }
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/Widget/MvxAppCompatSpinner.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/Widget/MvxAppCompatSpinner.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections;
+using System.Windows.Input;
+using Android.Content;
+using Android.Runtime;
+using Android.Support.V7.Widget;
+using Android.Util;
+using Cirrious.MvvmCross.Binding.Attributes;
+using Cirrious.MvvmCross.Binding.Droid.Views;
+
+namespace Cirrious.MvvmCross.Droid.Support.AppCompat.Widget
+{
+    /// <summary>
+    /// Tint-aware version of MvxSpinner styled properly with AppCompat V22.2+.
+    /// TODO: We may want to figure out a way to delegate to a common class for both.
+    /// </summary>
+    [Register("cirrious.mvvmcross.droid.support.appcompat.widget.MvxAppCompatSpinner")]
+    public class MvxAppCompatSpinner : AppCompatSpinner
+    {
+        public MvxAppCompatSpinner(Context context, IAttributeSet attrs)
+            : this(
+                context, attrs,
+                new MvxAdapter(context)
+                {
+                    SimpleViewLayoutId = global::Android.Resource.Layout.SimpleDropDownItem1Line
+                }) {}
+
+        public MvxAppCompatSpinner(Context context, IAttributeSet attrs, IMvxAdapter adapter)
+            : base(context, attrs)
+        {
+            var itemTemplateId = MvxAttributeHelpers.ReadListItemTemplateId(context, attrs);
+            var dropDownItemTemplateId = MvxAttributeHelpers.ReadDropDownListItemTemplateId(context, attrs);
+            adapter.ItemTemplateId = itemTemplateId;
+            adapter.DropDownItemTemplateId = dropDownItemTemplateId;
+            Adapter = adapter;
+            SetupHandleItemSelected();
+        }
+
+        protected MvxAppCompatSpinner(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer) {}
+
+        public new IMvxAdapter Adapter
+        {
+            get { return base.Adapter as IMvxAdapter; }
+            set
+            {
+                var existing = Adapter;
+                if (existing == value)
+                    return;
+
+                if (existing != null && value != null)
+                {
+                    value.ItemsSource = existing.ItemsSource;
+                    value.ItemTemplateId = existing.ItemTemplateId;
+                }
+
+                base.Adapter = value;
+            }
+        }
+
+        [MvxSetToNullAfterBinding]
+        public IEnumerable ItemsSource
+        {
+            get { return Adapter.ItemsSource; }
+            set { Adapter.ItemsSource = value; }
+        }
+
+        public int ItemTemplateId
+        {
+            get { return Adapter.ItemTemplateId; }
+            set { Adapter.ItemTemplateId = value; }
+        }
+
+        public int DropDownItemTemplateId
+        {
+            get { return Adapter.DropDownItemTemplateId; }
+            set { Adapter.DropDownItemTemplateId = value; }
+        }
+
+        public ICommand HandleItemSelected { get; set; }
+
+        private void SetupHandleItemSelected()
+        {
+            base.ItemSelected += (sender, args) =>
+            {
+                var position = args.Position;
+                HandleSelected(position);
+            };
+        }
+
+        protected virtual void HandleSelected(int position)
+        {
+            var item = Adapter.GetRawItem(position);
+            if (this.HandleItemSelected == null
+                || item == null
+                || !this.HandleItemSelected.CanExecute(item))
+                return;
+
+            this.HandleItemSelected.Execute(item);
+        }
+    }
+}


### PR DESCRIPTION
Add a tint aware version of `MvxSpinner` to activities that support AppCompat.  Replaces `MvxSpinner` on inflation.

To make this bind properly to `SelectedItem` call `MvxAppCompatSetupHelper.FillTargetFactories` from your `MvxSetup.FillTargetFactories`.
