### PR TITLE
Use inflated view when passing it into CompatDelegate

### DIFF
--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
@@ -14,6 +14,7 @@ using Android.Support.V7.App;
 using Android.Support.V7.Widget;
 using Android.Util;
 using Android.Views;
+using Cirrious.MvvmCross.Binding.Droid.BindingContext;
 using Cirrious.MvvmCross.Droid.Views;
 using Java.Lang;
 
@@ -69,7 +70,8 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
 
         public override void SetContentView(int layoutResId)
         {
-            CompatDelegate.SetContentView(layoutResId);
+            var view = this.BindingInflate(layoutResId, null);
+            CompatDelegate.SetContentView(view);
         }
 
         public override void SetContentView(View view)

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
@@ -16,6 +16,7 @@ using Android.Util;
 using Android.Views;
 using Cirrious.MvvmCross.Binding.Droid.BindingContext;
 using Cirrious.MvvmCross.Droid.Views;
+using Cirrious.MvvmCross.ViewModels;
 using Java.Lang;
 
 namespace Cirrious.MvvmCross.Droid.Support.AppCompat
@@ -119,8 +120,10 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             CompatDelegate.OnDestroy();
         }
 
-        public override void InvalidateOptionsMenu()
+        public void InvalidateOptionsMenu()
         {
+            // We don't use override, based upon the google example:
+            // https://android.googlesource.com/platform/development/+/master/samples/Support7Demos/src/com/example/android/supportv7/app/AppCompatPreferenceActivity.java
             CompatDelegate.InvalidateOptionsMenu();
         }
 

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxActivityCompat.cs
@@ -119,7 +119,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             CompatDelegate.OnDestroy();
         }
 
-        public void InvalidateOptionsMenu()
+        public override void InvalidateOptionsMenu()
         {
             CompatDelegate.InvalidateOptionsMenu();
         }


### PR DESCRIPTION
Created a new pull request to adjust only fix the bug instead of introducing not needed classes. 

@kjeremy I left the license for you :)
