### PR TITLE
Pass java ownership down to base class constructor

### DIFF
--- a/Cirrious.MvvmCross.Droid.Support.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/Fragments/EventSource/MvxEventSourceListFragment.cs
@@ -37,7 +37,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging.Fragments.EventSource
 
         protected MvxEventSourceListFragment() { }
 
-        protected MvxEventSourceListFragment(IntPtr javaReference, JniHandleOwnership transfer) { }
+        protected MvxEventSourceListFragment(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
 
         public override void OnAttach(Activity activity)
         {

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -51,6 +51,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         }
 
         protected MvxCachingFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
         {
             BindingContext = new MvxAndroidBindingContext(this, this);
             this.AddEventListeners();

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxEventSourceFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxEventSourceFragmentActivity.cs
@@ -23,7 +23,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         protected MvxEventSourceFragmentActivity()
         {
         }
-        protected MvxEventSourceFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer) { }
+        protected MvxEventSourceFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
 
         protected override void OnCreate(Bundle bundle)
         {

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxFragmentActivity.cs
@@ -26,6 +26,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         }
 
         protected MvxFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
         {
             BindingContext = new MvxAndroidBindingContext(this, this);
             this.AddEventListeners();


### PR DESCRIPTION
Pass the java handle down to the base.

This is more important in fragments since they can be instantiated from XML.
