### PR TITLE
Fix cache issue

### DIFF
--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -33,6 +33,13 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
         private Dictionary<int, string> _currentFragments = new Dictionary<int, string>();
         private IList<KeyValuePair<int, string>> _backStackFragments = new List<KeyValuePair<int, string>>();
 
+        enum FragmentReplaceMode
+        {
+            NoReplace,
+            ReplaceFragment,
+            ReplaceFragmentAndViewModel
+        }
+
         /// <summary>
         ///     Register a Fragment to be shown, this should usually be done in OnCreate
         /// </summary>
@@ -231,8 +238,12 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
-            var shouldReplaceCurrentFragment = forceReplaceFragment || ShouldReplaceCurrentFragment(contentId, tag);
-            if (!shouldReplaceCurrentFragment)
+            FragmentReplaceMode replaceMode = FragmentReplaceMode.ReplaceFragmentAndViewModel;
+
+            if (!forceReplaceFragment)
+                replaceMode = ShouldReplaceFragment(contentId, fragInfo, currentFragment, bundle);
+
+            if (replaceMode == FragmentReplaceMode.NoReplace)
                 return;
 
             var ft = SupportFragmentManager.BeginTransaction();
@@ -244,8 +255,12 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
-            if (fragInfo.CachedFragment == null || shouldReplaceCurrentFragment)
+            if (fragInfo.CachedFragment == null || replaceMode == FragmentReplaceMode.ReplaceFragmentAndViewModel)
             {
+
+                var viewModelCache = Mvx.GetSingleton<IMvxMultipleViewModelCache>();
+                viewModelCache.GetAndClear(fragInfo.ViewModelType);
+
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
 
@@ -264,17 +279,41 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             SupportFragmentManager.ExecutePendingTransactions();
         }
 
-        private bool ShouldReplaceCurrentFragment(int contentId, string tag)
+        private FragmentReplaceMode ShouldReplaceFragment(int contentId, FragmentInfo fragment, string currentTag, Bundle replacementBundle)
         {
-            string currentFragment;
-            _currentFragments.TryGetValue(contentId, out currentFragment);
+            if (fragment.CachedFragment == null) return FragmentReplaceMode.ReplaceFragment;
+            if (currentTag == fragment.Tag)
+            {
+                var oldBundle = fragment.CachedFragment.Arguments;
+                if (oldBundle == null) return FragmentReplaceMode.ReplaceFragmentAndViewModel;
 
-            return ShouldReplaceFragment(contentId, currentFragment, tag);
-        }
+                var serializer = Mvx.Resolve<IMvxNavigationSerializer>();
 
-        protected virtual bool ShouldReplaceFragment(int contentId, string currentTag, string replacementTag)
-        {
-            return currentTag != replacementTag;
+                var json = oldBundle.GetString("__mvxViewModelRequest");
+                var oldRequest = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
+                if (oldRequest == null) return FragmentReplaceMode.ReplaceFragmentAndViewModel;
+
+                json = replacementBundle.GetString("__mvxViewModelRequest");
+                var replacementRequest = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
+                if (replacementRequest == null) return FragmentReplaceMode.ReplaceFragmentAndViewModel;
+
+                var areParametersEqual = ((oldRequest.ParameterValues == replacementRequest.ParameterValues) ||
+             (oldRequest.ParameterValues.Count == replacementRequest.ParameterValues.Count &&
+             !oldRequest.ParameterValues.Except(replacementRequest.ParameterValues).Any()));
+
+                if (!areParametersEqual)
+                {
+                    return FragmentReplaceMode.ReplaceFragmentAndViewModel;
+                }
+                else
+                {
+                    return FragmentReplaceMode.NoReplace;
+                }
+            }
+            else
+            {
+                return FragmentReplaceMode.ReplaceFragment;
+            }
         }
 
         private void RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -33,6 +33,13 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         private Dictionary<int, string> _currentFragments = new Dictionary<int, string>();
         private IList<KeyValuePair<int, string>> _backStackFragments = new List<KeyValuePair<int, string>>();
 
+        enum FragmentReplaceMode
+        {
+            NoReplace,
+            ReplaceFragment,
+            ReplaceFragmentAndViewModel
+        }
+
         /// <summary>
         ///     Register a Fragment to be shown, this should usually be done in OnCreate
         /// </summary>
@@ -229,8 +236,12 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
-            var shouldReplaceCurrentFragment = forceReplaceFragment || ShouldReplaceCurrentFragment(contentId, fragInfo, currentFragment, bundle);
-            if (!shouldReplaceCurrentFragment)
+            FragmentReplaceMode replaceMode = FragmentReplaceMode.ReplaceFragmentAndViewModel;
+
+            if (!forceReplaceFragment)
+                replaceMode = ShouldReplaceFragment(contentId, fragInfo, currentFragment, bundle);
+
+            if (replaceMode == FragmentReplaceMode.NoReplace)
                 return;
 
             var ft = SupportFragmentManager.BeginTransaction();
@@ -242,13 +253,11 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
-            if (fragInfo.CachedFragment == null || shouldReplaceCurrentFragment)
+            if (fragInfo.CachedFragment == null || replaceMode == FragmentReplaceMode.ReplaceFragmentAndViewModel)
             {
-                if (shouldReplaceCurrentFragment)
-                {
-                    var viewModelCache = Mvx.GetSingleton<IMvxMultipleViewModelCache>();
-                    viewModelCache.GetAndClear(fragInfo.ViewModelType);
-                }
+
+                var viewModelCache = Mvx.GetSingleton<IMvxMultipleViewModelCache>();
+                viewModelCache.GetAndClear(fragInfo.ViewModelType);
 
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
@@ -268,33 +277,40 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             SupportFragmentManager.ExecutePendingTransactions();
         }
 
-        private bool ShouldReplaceCurrentFragment(int contentId, FragmentInfo fragment, string currentTag, Bundle replacementBundle)
+        private FragmentReplaceMode ShouldReplaceFragment(int contentId, FragmentInfo fragment, string currentTag, Bundle replacementBundle)
         {
-            if (fragment == null || fragment.CachedFragment == null) return true;
+            if (fragment.CachedFragment == null) return FragmentReplaceMode.ReplaceFragment;
             if (currentTag == fragment.Tag)
             {
                 var oldBundle = fragment.CachedFragment.Arguments;
-                if (oldBundle == null) return true;
+                if (oldBundle == null) return FragmentReplaceMode.ReplaceFragmentAndViewModel;
 
                 var serializer = Mvx.Resolve<IMvxNavigationSerializer>();
 
                 var json = oldBundle.GetString("__mvxViewModelRequest");
                 var oldRequest = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
-                if (oldRequest == null) return true;
+                if (oldRequest == null) return FragmentReplaceMode.ReplaceFragmentAndViewModel;
 
                 json = replacementBundle.GetString("__mvxViewModelRequest");
                 var replacementRequest = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
-                if (replacementRequest == null) return true;
+                if (replacementRequest == null) return FragmentReplaceMode.ReplaceFragmentAndViewModel;
 
                 var areParametersEqual = ((oldRequest.ParameterValues == replacementRequest.ParameterValues) ||
              (oldRequest.ParameterValues.Count == replacementRequest.ParameterValues.Count &&
              !oldRequest.ParameterValues.Except(replacementRequest.ParameterValues).Any()));
 
-                return !areParametersEqual;
+                if (!areParametersEqual)
+                {
+                    return FragmentReplaceMode.ReplaceFragmentAndViewModel;
+                }
+                else
+                {
+                    return FragmentReplaceMode.NoReplace;
+                }
             }
             else
             {
-                return true;
+                return FragmentReplaceMode.ReplaceFragment;
             }
         }
 

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -229,7 +229,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             string currentFragment;
             _currentFragments.TryGetValue(contentId, out currentFragment);
 
-            var shouldReplaceCurrentFragment = forceReplaceFragment || ShouldReplaceCurrentFragment(contentId, tag);
+            var shouldReplaceCurrentFragment = forceReplaceFragment || ShouldReplaceCurrentFragment(contentId, fragInfo, currentFragment, bundle);
             if (!shouldReplaceCurrentFragment)
                 return;
 
@@ -244,6 +244,12 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             // if we haven't already created a Fragment, do it now
             if (fragInfo.CachedFragment == null || shouldReplaceCurrentFragment)
             {
+                if (shouldReplaceCurrentFragment)
+                {
+                    var viewModelCache = Mvx.GetSingleton<IMvxMultipleViewModelCache>();
+                    viewModelCache.GetAndClear(fragInfo.ViewModelType);
+                }
+
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
 
@@ -262,16 +268,34 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             SupportFragmentManager.ExecutePendingTransactions();
         }
 
-        private bool ShouldReplaceCurrentFragment(int contentId, string tag)
+        private bool ShouldReplaceCurrentFragment(int contentId, FragmentInfo fragment, string currentTag, Bundle replacementBundle)
         {
-            string currentFragment;
-            _currentFragments.TryGetValue(contentId, out currentFragment);
+            if (fragment == null || fragment.CachedFragment == null) return true;
+            if (currentTag == fragment.Tag)
+            {
+                var oldBundle = fragment.CachedFragment.Arguments;
+                if (oldBundle == null) return true;
 
-            return ShouldReplaceFragment(contentId, currentFragment, tag);
-        }
+                var serializer = Mvx.Resolve<IMvxNavigationSerializer>();
 
-        protected virtual bool ShouldReplaceFragment(int contentId, string currentTag, string replacementTag)  {
-            return currentTag != replacementTag;
+                var json = oldBundle.GetString("__mvxViewModelRequest");
+                var oldRequest = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
+                if (oldRequest == null) return true;
+
+                json = replacementBundle.GetString("__mvxViewModelRequest");
+                var replacementRequest = serializer.Serializer.DeserializeObject<MvxViewModelRequest>(json);
+                if (replacementRequest == null) return true;
+
+                var areParametersEqual = ((oldRequest.ParameterValues == replacementRequest.ParameterValues) ||
+             (oldRequest.ParameterValues.Count == replacementRequest.ParameterValues.Count &&
+             !oldRequest.ParameterValues.Except(replacementRequest.ParameterValues).Any()));
+
+                return !areParametersEqual;
+            }
+            else
+            {
+                return true;
+            }
         }
 
         private void RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)


### PR DESCRIPTION
Fixes #62 

I think this is sensible fix although I accept that you could be showing the same fragment again with the same data and this change would now force a new viewmodel to be created.  Comparing bundles would be the only way to completely fix this but I suspect it would be overkill.
