### PR TITLE
Fixed bug: Cached fragments never used and fragmentManager edge case

### DIFF
--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -256,6 +256,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
                 ft.Add(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
+                OnFragmentCreated(fragInfo, ft);
             }
             else
             {
@@ -365,6 +366,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
 
         public virtual void OnFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
         public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
+        public virtual void OnFragmentCreated(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)
         {

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -273,6 +273,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             OnFragmentChanging(tag, ft);
             ft.Commit();
             SupportFragmentManager.ExecutePendingTransactions();
+            OnFragmentChanged(fragInfo);
         }
 
         private bool ShouldReplaceCurrentFragment(int contentId, string tag)
@@ -316,6 +317,8 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
                 _backStackFragments.Remove(currentFragment);
 
                 SupportFragmentManager.PopBackStackImmediate();
+                OnFragmentChanged(GetFragmentInfoByTag(currentFragment.Value));
+
                 return;
             }
             else if (SupportFragmentManager.BackStackEntryCount == 1)
@@ -361,6 +364,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
         public virtual void OnBeforeFragmentChanging(string tag, FragmentTransaction transaction) { }
 
         public virtual void OnFragmentChanging(string tag, FragmentTransaction transaction) { }
+        public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)
         {

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -224,9 +224,9 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
         /// <param name="tag">The tag for the fragment to lookup</param>
         /// <param name="contentId">Where you want to show the Fragment</param>
         /// <param name="bundle">Bundle which usually contains a Serialized MvxViewModelRequest</param>
-        /// <param name="addToBackStack">If you want to add the fragment to the backstack so on backbutton it will go back to it</param>
+        /// <param name="forceAddToBackStack">If you want to force add the fragment to the backstack so on backbutton it will go back to it. Note: This will override IMvxCachedFragmentInfo.AddToBackStack configuration.</param>
         /// <param name="forceReplaceFragment">Force replace a fragment with the same viewmodel at the same contentid</param>
-        protected void ShowFragment(string tag, int contentId, Bundle bundle = null, bool addToBackStack = false, bool forceReplaceFragment = false)
+        protected void ShowFragment(string tag, int contentId, Bundle bundle = null, bool forceAddToBackStack = false, bool forceReplaceFragment = false)
         {
             IMvxCachedFragmentInfo fragInfo;
             _lookup.TryGetValue(tag, out fragInfo);
@@ -268,7 +268,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
 
             _currentFragments[contentId] = fragInfo.Tag;
 
-            if (addToBackStack)
+            if (fragInfo.AddToBackStack || forceAddToBackStack)
                 ft.AddToBackStack(fragInfo.Tag);
 
             OnFragmentChanging(fragInfo, ft);

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -240,19 +240,24 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
 
             // if there is a Fragment showing on the contentId we want to present at
             // remove it first.   
-            RemoveFragmentIfShowing(ft, contentId);
+            var wasDetached = RemoveFragmentIfShowing(ft, contentId);
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
-            if (fragInfo.CachedFragment == null || shouldReplaceCurrentFragment)
+            if (fragInfo.CachedFragment == null)
             {
+                //Otherwise, create one and cache it
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
-
                 ft.Add(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
             }
             else
-                ft.Attach(fragInfo.CachedFragment);
+            {
+                if (wasDetached)
+                    ft.Attach(fragInfo.CachedFragment);
+                else
+                    ft.Replace(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
+            }
 
             _currentFragments[contentId] = fragInfo.Tag;
 
@@ -277,10 +282,10 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             return currentTag != replacementTag;
         }
 
-        private void RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)
+        private bool RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)
         {
             var frag = SupportFragmentManager.FindFragmentById(contentId);
-            if (frag == null) return;
+            if (frag == null) return false;
 
             ft.Detach(frag);
 
@@ -288,6 +293,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             _backStackFragments.Add(currentFragment);
 
             _currentFragments.Remove(contentId);
+            return true;
         }
 
         public override void OnBackPressed()

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -242,7 +242,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
                 return;
 
             var ft = SupportFragmentManager.BeginTransaction();
-            OnBeforeFragmentChanging(tag, ft);
+            OnBeforeFragmentChanging(fragInfo, ft);
 
             // if there is a Fragment showing on the contentId we want to present at
             // remove it first.   
@@ -270,7 +270,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             if (addToBackStack)
                 ft.AddToBackStack(fragInfo.Tag);
 
-            OnFragmentChanging(tag, ft);
+            OnFragmentChanging(fragInfo, ft);
             ft.Commit();
             SupportFragmentManager.ExecutePendingTransactions();
             OnFragmentChanged(fragInfo);
@@ -361,9 +361,9 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             return namespaceText + fragmentType.Name;
         }
 
-        public virtual void OnBeforeFragmentChanging(string tag, FragmentTransaction transaction) { }
+        public virtual void OnBeforeFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
 
-        public virtual void OnFragmentChanging(string tag, FragmentTransaction transaction) { }
+        public virtual void OnFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
         public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)

--- a/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -246,7 +246,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
 
             // if there is a Fragment showing on the contentId we want to present at
             // remove it first.   
-            var wasDetached = RemoveFragmentIfShowing(ft, contentId);
+            RemoveFragmentIfShowing(ft, contentId);
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
@@ -255,16 +255,10 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
                 //Otherwise, create one and cache it
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
-                ft.Add(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
                 OnFragmentCreated(fragInfo, ft);
             }
-            else
-            {
-                if (wasDetached)
-                    ft.Attach(fragInfo.CachedFragment);
-                else
-                    ft.Replace(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
-            }
+
+            ft.Replace(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
 
             _currentFragments[contentId] = fragInfo.Tag;
 
@@ -295,7 +289,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             var frag = SupportFragmentManager.FindFragmentById(contentId);
             if (frag == null) return false;
 
-            ft.Detach(frag);
+            //TODO Since all the fragments will be replaced do we really need to track this?
 
             var currentFragment = _currentFragments.First(x => x.Key == contentId);
             _backStackFragments.Add(currentFragment);
@@ -342,7 +336,7 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
             if (frag == null) return;
 
             SupportFragmentManager.PopBackStackImmediate(tag, 1);
-
+            
             _currentFragments.Remove(contentId);
 
             if (_backStackFragments.Count > 0 && _backStackFragments.Any(x => x.Key == contentId))
@@ -363,7 +357,6 @@ namespace Cirrious.MvvmCross.Droid.Support.AppCompat
         }
 
         public virtual void OnBeforeFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
-
         public virtual void OnFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
         public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
         public virtual void OnFragmentCreated(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/Cirrious.MvvmCross.Droid.Support.Fragging.csproj
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/Cirrious.MvvmCross.Droid.Support.Fragging.csproj
@@ -81,6 +81,8 @@
     <Compile Include="Fragments\EventSource\MvxBaseFragmentAdapter.cs" />
     <Compile Include="Fragments\MvxBindingFragmentAdapter.cs" />
     <Compile Include="Fragments\MvxSimpleLayoutInflaterHolder.cs" />
+    <Compile Include="IMvxCachedFragmentInfo.cs" />
+    <Compile Include="MvxCachedFragmentInfo.cs" />
     <Compile Include="MvxOwnedViewModelFragmentAttribute.cs" />
     <Compile Include="MvxOwnedViewModelFragmentAttributeExtensionMethods.cs" />
     <Compile Include="MvxCachingFragmentActivity.cs" />

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/IMvxCachedFragmentInfo.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/IMvxCachedFragmentInfo.cs
@@ -5,10 +5,12 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 {
     public interface IMvxCachedFragmentInfo
     {
-        string Tag { get; }
-        Type FragmentType { get; }
-        Type ViewModelType { get; }
+        string Tag { get; set;  }
+        Type FragmentType { get; set; }
+        Type ViewModelType { get; set; }
         Fragment CachedFragment { get; set; }
         int ContentId { get; set; }
+        bool AddToBackStack { get; set; }
+
     }
 }

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/IMvxCachedFragmentInfo.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/IMvxCachedFragmentInfo.cs
@@ -1,0 +1,14 @@
+using System;
+using Android.Support.V4.App;
+
+namespace Cirrious.MvvmCross.Droid.Support.Fragging
+{
+    public interface IMvxCachedFragmentInfo
+    {
+        string Tag { get; }
+        Type FragmentType { get; }
+        Type ViewModelType { get; }
+        Fragment CachedFragment { get; set; }
+        int ContentId { get; set; }
+    }
+}

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachedFragmentInfo.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachedFragmentInfo.cs
@@ -1,0 +1,21 @@
+using System;
+using Android.Support.V4.App;
+
+namespace Cirrious.MvvmCross.Droid.Support.Fragging
+{
+    public class MvxCachedFragmentInfo : IMvxCachedFragmentInfo
+    {
+        public MvxCachedFragmentInfo(string tag, Type fragmentType, Type viewModelType)
+        {
+            Tag = tag;
+            FragmentType = fragmentType;
+            ViewModelType = viewModelType;
+        }
+
+        public string Tag { get; private set; }
+        public Type FragmentType { get; private set; }
+        public Type ViewModelType { get; private set; }
+        public Fragment CachedFragment { get; set; }
+        public int ContentId { get; set; }
+    }
+}

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachedFragmentInfo.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachedFragmentInfo.cs
@@ -12,10 +12,12 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             ViewModelType = viewModelType;
         }
 
-        public string Tag { get; private set; }
-        public Type FragmentType { get; private set; }
-        public Type ViewModelType { get; private set; }
+        public string Tag { get; set; }
+        public Type FragmentType { get; set; }
+        public Type ViewModelType { get; set; }
         public Fragment CachedFragment { get; set; }
         public int ContentId { get; set; }
+        public bool AddToBackStack { get; set; }
+
     }
 }

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -242,7 +242,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
             // if there is a Fragment showing on the contentId we want to present at
             // remove it first.   
-            var wasDetached = RemoveFragmentIfShowing(ft, contentId);
+            RemoveFragmentIfShowing(ft, contentId);
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
@@ -251,17 +251,11 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
                 //Otherwise, create one and cache it
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
-                ft.Add(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
                 OnFragmentCreated(fragInfo, ft);
             }
-            else
-            {
-                if (wasDetached)
-                    ft.Attach(fragInfo.CachedFragment);
-                else
-                    ft.Replace(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
-            }
 
+            ft.Replace(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
+            
             _currentFragments[contentId] = fragInfo.Tag;
 
             if (fragInfo.AddToBackStack || forceAddToBackStack)
@@ -290,9 +284,9 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             var frag = SupportFragmentManager.FindFragmentById(contentId);
             if (frag == null) return false;
 
-            ft.Detach(frag);
+            //TODO Since all the fragments will be replaced do we really need to track this?
 
-            var currentFragment = _currentFragments.First (x => x.Key == contentId);           
+            var currentFragment = _currentFragments.First(x => x.Key == contentId);           
             _backStackFragments.Add (currentFragment);
 
             _currentFragments.Remove(contentId);

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -224,7 +224,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         /// <param name="forceReplaceFragment">Force replace a fragment with the same viewmodel at the same contentid</param>
         protected void ShowFragment(string tag, int contentId, Bundle bundle = null, bool addToBackStack = false, bool forceReplaceFragment = false)
         {
-            MvxCachedFragmentInfo fragInfo;
+            IMvxCachedFragmentInfo fragInfo;
             _lookup.TryGetValue(tag, out fragInfo);
 
             if (fragInfo == null)
@@ -352,7 +352,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)
         {
-            MvxCachedFragmentInfo fragInfo;
+            IMvxCachedFragmentInfo fragInfo;
             _lookup.TryGetValue(tag, out fragInfo);
 
             if (fragInfo == null)

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -29,7 +29,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         private const string SavedFragmentTypesKey = "__mvxSavedFragmentTypes";
         private const string SavedCurrentFragmentsKey = "__mvxSavedCurrentFragments";
         private const string SavedBackStackFragmentsKey = "__mvxSavedBackStackFragments";
-        private readonly Dictionary<string, FragmentInfo> _lookup = new Dictionary<string, FragmentInfo>();
+        private readonly Dictionary<string, MvxCachedFragmentInfo> _lookup = new Dictionary<string, MvxCachedFragmentInfo>();
         private Dictionary<int, string> _currentFragments = new Dictionary<int, string>();
         private IList<KeyValuePair<int, string>> _backStackFragments = new List<KeyValuePair<int, string>>();
 
@@ -43,7 +43,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             where TFragment : IMvxFragmentView
             where TViewModel : IMvxViewModel
         {
-            var fragInfo = new FragmentInfo(tag, typeof(TFragment), typeof(TViewModel));
+            var fragInfo = new MvxCachedFragmentInfo(tag, typeof(TFragment), typeof(TViewModel));
 
             _lookup.Add(tag, fragInfo);
         }
@@ -220,7 +220,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         /// <param name="forceReplaceFragment">Force replace a fragment with the same viewmodel at the same contentid</param>
         protected void ShowFragment(string tag, int contentId, Bundle bundle = null, bool addToBackStack = false, bool forceReplaceFragment = false)
         {
-            FragmentInfo fragInfo;
+            MvxCachedFragmentInfo fragInfo;
             _lookup.TryGetValue(tag, out fragInfo);
 
             if (fragInfo == null)
@@ -346,32 +346,15 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
         public virtual void OnFragmentChanging(string tag, FragmentTransaction transaction) { }
 
-        protected FragmentInfo GetFragmentInfoByTag(string tag)
+        protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)
         {
-            FragmentInfo fragInfo;
+            MvxCachedFragmentInfo fragInfo;
             _lookup.TryGetValue(tag, out fragInfo);
 
             if (fragInfo == null)
                 throw new MvxException("Could not find tag: {0} in cache, you need to register it first.", tag);
             return fragInfo;
         }
-
-        protected class FragmentInfo
-        {
-            public FragmentInfo(string tag, Type fragmentType, Type viewModelType)
-            {
-                Tag = tag;
-                FragmentType = fragmentType;
-                ViewModelType = viewModelType;
-            }
-
-            public string Tag { get; private set; }
-            public Type FragmentType { get; private set; }
-            public Type ViewModelType { get; private set; }
-            public Fragment CachedFragment { get; set; }
-            public int ContentId { get; set; }
-        }
-        
     }
 
     public abstract class MvxCachingFragmentActivity<TViewModel>

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -238,19 +238,24 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
             // if there is a Fragment showing on the contentId we want to present at
             // remove it first.   
-            RemoveFragmentIfShowing(ft, contentId);
+            var wasDetached = RemoveFragmentIfShowing(ft, contentId);
 
             fragInfo.ContentId = contentId;
             // if we haven't already created a Fragment, do it now
-            if (fragInfo.CachedFragment == null || shouldReplaceCurrentFragment)
+            if (fragInfo.CachedFragment == null)
             {
+                //Otherwise, create one and cache it
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
-
                 ft.Add(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
             }
             else
-                ft.Attach(fragInfo.CachedFragment);
+            {
+                if (wasDetached)
+                    ft.Attach(fragInfo.CachedFragment);
+                else
+                    ft.Replace(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
+            }
 
             _currentFragments[contentId] = fragInfo.Tag;
 
@@ -274,10 +279,10 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             return currentTag != replacementTag;
         }
 
-        private void RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)
+        private bool RemoveFragmentIfShowing(FragmentTransaction ft, int contentId)
         {
             var frag = SupportFragmentManager.FindFragmentById(contentId);
-            if (frag == null) return;
+            if (frag == null) return false;
 
             ft.Detach(frag);
 
@@ -285,6 +290,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             _backStackFragments.Add (currentFragment);
 
             _currentFragments.Remove(contentId);
+            return true;
         }
 
         public override void OnBackPressed ()

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -252,6 +252,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
                 fragInfo.CachedFragment = Fragment.Instantiate(this, FragmentJavaName(fragInfo.FragmentType),
                     bundle);
                 ft.Add(fragInfo.ContentId, fragInfo.CachedFragment, fragInfo.Tag);
+                OnFragmentCreated(fragInfo, ft);
             }
             else
             {
@@ -359,6 +360,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
         public virtual void OnFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
         public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
+        public virtual void OnFragmentCreated(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)
         {

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -220,9 +220,9 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         /// <param name="tag">The tag for the fragment to lookup</param>
         /// <param name="contentId">Where you want to show the Fragment</param>
         /// <param name="bundle">Bundle which usually contains a Serialized MvxViewModelRequest</param>
-        /// <param name="addToBackStack">If you want to add the fragment to the backstack so on backbutton it will go back to it</param>
+        /// <param name="forceAddToBackStack">If you want to force add the fragment to the backstack so on backbutton it will go back to it. Note: This will override IMvxCachedFragmentInfo.AddToBackStack configuration.</param>
         /// <param name="forceReplaceFragment">Force replace a fragment with the same viewmodel at the same contentid</param>
-        protected void ShowFragment(string tag, int contentId, Bundle bundle = null, bool addToBackStack = false, bool forceReplaceFragment = false)
+        protected void ShowFragment(string tag, int contentId, Bundle bundle = null, bool forceAddToBackStack = false, bool forceReplaceFragment = false)
         {
             IMvxCachedFragmentInfo fragInfo;
             _lookup.TryGetValue(tag, out fragInfo);
@@ -264,7 +264,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
 
             _currentFragments[contentId] = fragInfo.Tag;
 
-            if (addToBackStack)
+            if (fragInfo.AddToBackStack || forceAddToBackStack)
                 ft.AddToBackStack(fragInfo.Tag);
 
             OnFragmentChanging(fragInfo, ft);

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -29,7 +29,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         private const string SavedFragmentTypesKey = "__mvxSavedFragmentTypes";
         private const string SavedCurrentFragmentsKey = "__mvxSavedCurrentFragments";
         private const string SavedBackStackFragmentsKey = "__mvxSavedBackStackFragments";
-        private readonly Dictionary<string, MvxCachedFragmentInfo> _lookup = new Dictionary<string, MvxCachedFragmentInfo>();
+        private readonly Dictionary<string, IMvxCachedFragmentInfo> _lookup = new Dictionary<string, IMvxCachedFragmentInfo>();
         private Dictionary<int, string> _currentFragments = new Dictionary<int, string>();
         private IList<KeyValuePair<int, string>> _backStackFragments = new List<KeyValuePair<int, string>>();
 
@@ -43,9 +43,13 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             where TFragment : IMvxFragmentView
             where TViewModel : IMvxViewModel
         {
-            var fragInfo = new MvxCachedFragmentInfo(tag, typeof(TFragment), typeof(TViewModel));
-
+            var fragInfo = CreateFragmentInfo<TFragment, TViewModel>(tag);
             _lookup.Add(tag, fragInfo);
+        }
+
+        protected virtual IMvxCachedFragmentInfo CreateFragmentInfo<TFragment, TViewModel>(string tag)
+        {
+            return new MvxCachedFragmentInfo(tag, typeof(TFragment), typeof(TViewModel));
         }
 
         protected MvxCachingFragmentActivity()

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -238,7 +238,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
                 return;
 
             var ft = SupportFragmentManager.BeginTransaction();
-            OnBeforeFragmentChanging(tag, ft);
+            OnBeforeFragmentChanging(fragInfo, ft);
 
             // if there is a Fragment showing on the contentId we want to present at
             // remove it first.   
@@ -266,7 +266,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             if (addToBackStack)
                 ft.AddToBackStack(fragInfo.Tag);
 
-            OnFragmentChanging(tag, ft);
+            OnFragmentChanging(fragInfo, ft);
             ft.Commit();
             SupportFragmentManager.ExecutePendingTransactions();
             OnFragmentChanged(fragInfo);
@@ -355,9 +355,9 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             return namespaceText + fragmentType.Name;
         }
 
-        public virtual void OnBeforeFragmentChanging(string tag, FragmentTransaction transaction) { }
+        public virtual void OnBeforeFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
 
-        public virtual void OnFragmentChanging(string tag, FragmentTransaction transaction) { }
+        public virtual void OnFragmentChanging(IMvxCachedFragmentInfo fragmentInfo, FragmentTransaction transaction) { }
         public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)

--- a/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Fragging/MvxCachingFragmentActivity.cs
@@ -269,6 +269,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
             OnFragmentChanging(tag, ft);
             ft.Commit();
             SupportFragmentManager.ExecutePendingTransactions();
+            OnFragmentChanged(fragInfo);
         }
 
         private bool ShouldReplaceCurrentFragment(int contentId, string tag)
@@ -311,6 +312,8 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
                 _backStackFragments.Remove (currentFragment);
 
                 SupportFragmentManager.PopBackStackImmediate();
+                OnFragmentChanged(GetFragmentInfoByTag(currentFragment.Value));
+
                 return;
             }
             else if (SupportFragmentManager.BackStackEntryCount == 1)
@@ -355,6 +358,7 @@ namespace Cirrious.MvvmCross.Droid.Support.Fragging
         public virtual void OnBeforeFragmentChanging(string tag, FragmentTransaction transaction) { }
 
         public virtual void OnFragmentChanging(string tag, FragmentTransaction transaction) { }
+        public virtual void OnFragmentChanged(IMvxCachedFragmentInfo fragmentInfo) { }
 
         protected IMvxCachedFragmentInfo GetFragmentInfoByTag(string tag)
         {

--- a/Samples/Example.Droid/Activities/MainActivity.cs
+++ b/Samples/Example.Droid/Activities/MainActivity.cs
@@ -135,7 +135,7 @@ namespace Example.Droid.Activities
             }
             else
             {
-                ShowFragment(request.ViewModelType.Name, Resource.Id.content_frame, bundle, true);
+                ShowFragment(request.ViewModelType.Name, Resource.Id.content_frame, bundle);
                 return true;
             }
         }
@@ -162,9 +162,9 @@ namespace Example.Droid.Activities
 
         private static Dictionary<string, CustomFragmentInfo> myFragmentsInfo = new Dictionary<string, CustomFragmentInfo>()
         {
-            {typeof(MenuViewModel).Name, new CustomFragmentInfo(typeof(MenuViewModel).Name, typeof(MenuFragment), typeof(MenuViewModel))},
-            {typeof(ExamplesViewModel).Name, new CustomFragmentInfo( typeof(ExamplesViewModel).Name, typeof(ExamplesFragment), typeof(ExamplesViewModel), isRoot: true)},
-            {typeof(SettingsViewModel).Name, new CustomFragmentInfo( typeof(SettingsViewModel).Name, typeof(SettingsFragment), typeof(SettingsViewModel), isRoot: true)}
+            {typeof(MenuViewModel).Name, new CustomFragmentInfo(typeof(MenuViewModel).Name, typeof(MenuFragment), typeof(MenuViewModel),false)},
+            {typeof(ExamplesViewModel).Name, new CustomFragmentInfo( typeof(ExamplesViewModel).Name, typeof(ExamplesFragment), typeof(ExamplesViewModel), true, isRoot: true)},
+            {typeof(SettingsViewModel).Name, new CustomFragmentInfo( typeof(SettingsViewModel).Name, typeof(SettingsFragment), typeof(SettingsViewModel), true, isRoot: true)}
         };
 
         private static FragmentTransitionInfo fragTransitions = new FragmentTransitionInfo()
@@ -179,10 +179,10 @@ namespace Example.Droid.Activities
         public FragmentTransitionInfo TransitionInfo { get; set; }
         public bool IsRoot { get; set; }
 
-        public CustomFragmentInfo(string tag, Type fragmentType, Type viewModelType, FragmentTransitionInfo transitionInfo = null, bool isRoot = false)
+        public CustomFragmentInfo(string tag, Type fragmentType, Type viewModelType, bool addToBackstack, FragmentTransitionInfo transitionInfo = null, bool isRoot = false)
             : base(tag, fragmentType, viewModelType)
         {
-
+            AddToBackStack = addToBackstack;
             TransitionInfo = transitionInfo;
             IsRoot = isRoot;
         }

--- a/Samples/Example.Droid/Example.Droid.csproj
+++ b/Samples/Example.Droid/Example.Droid.csproj
@@ -159,4 +159,10 @@
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\splash.png" />
   </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\transition\slide_left.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\transition\slide_right.xml" />
+  </ItemGroup>
 </Project>

--- a/Samples/Example.Droid/Resources/Resource.designer.cs
+++ b/Samples/Example.Droid/Resources/Resource.designer.cs
@@ -909,26 +909,26 @@ namespace Example.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f090002
-			public const int abc_action_bar_embed_tabs = 2131296258;
+			// aapt resource value: 0x7f0a0002
+			public const int abc_action_bar_embed_tabs = 2131361794;
 			
-			// aapt resource value: 0x7f090000
-			public const int abc_action_bar_embed_tabs_pre_jb = 2131296256;
+			// aapt resource value: 0x7f0a0000
+			public const int abc_action_bar_embed_tabs_pre_jb = 2131361792;
 			
-			// aapt resource value: 0x7f090003
-			public const int abc_action_bar_expanded_action_views_exclusive = 2131296259;
+			// aapt resource value: 0x7f0a0003
+			public const int abc_action_bar_expanded_action_views_exclusive = 2131361795;
 			
-			// aapt resource value: 0x7f090004
-			public const int abc_config_actionMenuItemAllCaps = 2131296260;
+			// aapt resource value: 0x7f0a0004
+			public const int abc_config_actionMenuItemAllCaps = 2131361796;
 			
-			// aapt resource value: 0x7f090001
-			public const int abc_config_allowActionMenuItemTextWithIcon = 2131296257;
+			// aapt resource value: 0x7f0a0001
+			public const int abc_config_allowActionMenuItemTextWithIcon = 2131361793;
 			
-			// aapt resource value: 0x7f090005
-			public const int abc_config_closeDialogWhenTouchOutside = 2131296261;
+			// aapt resource value: 0x7f0a0005
+			public const int abc_config_closeDialogWhenTouchOutside = 2131361797;
 			
-			// aapt resource value: 0x7f090006
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131296262;
+			// aapt resource value: 0x7f0a0006
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131361798;
 			
 			static Boolean()
 			{
@@ -943,233 +943,233 @@ namespace Example.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0b0041
-			public const int abc_background_cache_hint_selector_material_dark = 2131427393;
+			// aapt resource value: 0x7f0c0041
+			public const int abc_background_cache_hint_selector_material_dark = 2131492929;
 			
-			// aapt resource value: 0x7f0b0042
-			public const int abc_background_cache_hint_selector_material_light = 2131427394;
+			// aapt resource value: 0x7f0c0042
+			public const int abc_background_cache_hint_selector_material_light = 2131492930;
 			
-			// aapt resource value: 0x7f0b0000
-			public const int abc_input_method_navigation_guard = 2131427328;
+			// aapt resource value: 0x7f0c0000
+			public const int abc_input_method_navigation_guard = 2131492864;
 			
-			// aapt resource value: 0x7f0b0043
-			public const int abc_primary_text_disable_only_material_dark = 2131427395;
+			// aapt resource value: 0x7f0c0043
+			public const int abc_primary_text_disable_only_material_dark = 2131492931;
 			
-			// aapt resource value: 0x7f0b0044
-			public const int abc_primary_text_disable_only_material_light = 2131427396;
+			// aapt resource value: 0x7f0c0044
+			public const int abc_primary_text_disable_only_material_light = 2131492932;
 			
-			// aapt resource value: 0x7f0b0045
-			public const int abc_primary_text_material_dark = 2131427397;
+			// aapt resource value: 0x7f0c0045
+			public const int abc_primary_text_material_dark = 2131492933;
 			
-			// aapt resource value: 0x7f0b0046
-			public const int abc_primary_text_material_light = 2131427398;
+			// aapt resource value: 0x7f0c0046
+			public const int abc_primary_text_material_light = 2131492934;
 			
-			// aapt resource value: 0x7f0b0047
-			public const int abc_search_url_text = 2131427399;
+			// aapt resource value: 0x7f0c0047
+			public const int abc_search_url_text = 2131492935;
 			
-			// aapt resource value: 0x7f0b0001
-			public const int abc_search_url_text_normal = 2131427329;
+			// aapt resource value: 0x7f0c0001
+			public const int abc_search_url_text_normal = 2131492865;
 			
-			// aapt resource value: 0x7f0b0002
-			public const int abc_search_url_text_pressed = 2131427330;
+			// aapt resource value: 0x7f0c0002
+			public const int abc_search_url_text_pressed = 2131492866;
 			
-			// aapt resource value: 0x7f0b0003
-			public const int abc_search_url_text_selected = 2131427331;
+			// aapt resource value: 0x7f0c0003
+			public const int abc_search_url_text_selected = 2131492867;
 			
-			// aapt resource value: 0x7f0b0048
-			public const int abc_secondary_text_material_dark = 2131427400;
+			// aapt resource value: 0x7f0c0048
+			public const int abc_secondary_text_material_dark = 2131492936;
 			
-			// aapt resource value: 0x7f0b0049
-			public const int abc_secondary_text_material_light = 2131427401;
+			// aapt resource value: 0x7f0c0049
+			public const int abc_secondary_text_material_light = 2131492937;
 			
-			// aapt resource value: 0x7f0b0004
-			public const int accent_material_dark = 2131427332;
+			// aapt resource value: 0x7f0c0004
+			public const int accent_material_dark = 2131492868;
 			
-			// aapt resource value: 0x7f0b0005
-			public const int accent_material_light = 2131427333;
+			// aapt resource value: 0x7f0c0005
+			public const int accent_material_light = 2131492869;
 			
-			// aapt resource value: 0x7f0b0006
-			public const int background_floating_material_dark = 2131427334;
+			// aapt resource value: 0x7f0c0006
+			public const int background_floating_material_dark = 2131492870;
 			
-			// aapt resource value: 0x7f0b0007
-			public const int background_floating_material_light = 2131427335;
+			// aapt resource value: 0x7f0c0007
+			public const int background_floating_material_light = 2131492871;
 			
-			// aapt resource value: 0x7f0b0008
-			public const int background_material_dark = 2131427336;
+			// aapt resource value: 0x7f0c0008
+			public const int background_material_dark = 2131492872;
 			
-			// aapt resource value: 0x7f0b0009
-			public const int background_material_light = 2131427337;
+			// aapt resource value: 0x7f0c0009
+			public const int background_material_light = 2131492873;
 			
-			// aapt resource value: 0x7f0b0040
-			public const int black = 2131427392;
+			// aapt resource value: 0x7f0c0040
+			public const int black = 2131492928;
 			
-			// aapt resource value: 0x7f0b000a
-			public const int bright_foreground_disabled_material_dark = 2131427338;
+			// aapt resource value: 0x7f0c000a
+			public const int bright_foreground_disabled_material_dark = 2131492874;
 			
-			// aapt resource value: 0x7f0b000b
-			public const int bright_foreground_disabled_material_light = 2131427339;
+			// aapt resource value: 0x7f0c000b
+			public const int bright_foreground_disabled_material_light = 2131492875;
 			
-			// aapt resource value: 0x7f0b000c
-			public const int bright_foreground_inverse_material_dark = 2131427340;
+			// aapt resource value: 0x7f0c000c
+			public const int bright_foreground_inverse_material_dark = 2131492876;
 			
-			// aapt resource value: 0x7f0b000d
-			public const int bright_foreground_inverse_material_light = 2131427341;
+			// aapt resource value: 0x7f0c000d
+			public const int bright_foreground_inverse_material_light = 2131492877;
 			
-			// aapt resource value: 0x7f0b000e
-			public const int bright_foreground_material_dark = 2131427342;
+			// aapt resource value: 0x7f0c000e
+			public const int bright_foreground_material_dark = 2131492878;
 			
-			// aapt resource value: 0x7f0b000f
-			public const int bright_foreground_material_light = 2131427343;
+			// aapt resource value: 0x7f0c000f
+			public const int bright_foreground_material_light = 2131492879;
 			
-			// aapt resource value: 0x7f0b0010
-			public const int button_material_dark = 2131427344;
+			// aapt resource value: 0x7f0c0010
+			public const int button_material_dark = 2131492880;
 			
-			// aapt resource value: 0x7f0b0011
-			public const int button_material_light = 2131427345;
+			// aapt resource value: 0x7f0c0011
+			public const int button_material_light = 2131492881;
 			
-			// aapt resource value: 0x7f0b003e
-			public const int colorAccent = 2131427390;
+			// aapt resource value: 0x7f0c003e
+			public const int colorAccent = 2131492926;
 			
-			// aapt resource value: 0x7f0b003c
-			public const int colorPrimary = 2131427388;
+			// aapt resource value: 0x7f0c003c
+			public const int colorPrimary = 2131492924;
 			
-			// aapt resource value: 0x7f0b003d
-			public const int colorPrimaryDark = 2131427389;
+			// aapt resource value: 0x7f0c003d
+			public const int colorPrimaryDark = 2131492925;
 			
-			// aapt resource value: 0x7f0b0012
-			public const int dim_foreground_disabled_material_dark = 2131427346;
+			// aapt resource value: 0x7f0c0012
+			public const int dim_foreground_disabled_material_dark = 2131492882;
 			
-			// aapt resource value: 0x7f0b0013
-			public const int dim_foreground_disabled_material_light = 2131427347;
+			// aapt resource value: 0x7f0c0013
+			public const int dim_foreground_disabled_material_light = 2131492883;
 			
-			// aapt resource value: 0x7f0b0014
-			public const int dim_foreground_material_dark = 2131427348;
+			// aapt resource value: 0x7f0c0014
+			public const int dim_foreground_material_dark = 2131492884;
 			
-			// aapt resource value: 0x7f0b0015
-			public const int dim_foreground_material_light = 2131427349;
+			// aapt resource value: 0x7f0c0015
+			public const int dim_foreground_material_light = 2131492885;
 			
-			// aapt resource value: 0x7f0b0033
-			public const int error_color = 2131427379;
+			// aapt resource value: 0x7f0c0033
+			public const int error_color = 2131492915;
 			
-			// aapt resource value: 0x7f0b0034
-			public const int fab_stroke_end_inner_color = 2131427380;
+			// aapt resource value: 0x7f0c0034
+			public const int fab_stroke_end_inner_color = 2131492916;
 			
-			// aapt resource value: 0x7f0b0035
-			public const int fab_stroke_end_outer_color = 2131427381;
+			// aapt resource value: 0x7f0c0035
+			public const int fab_stroke_end_outer_color = 2131492917;
 			
-			// aapt resource value: 0x7f0b0036
-			public const int fab_stroke_top_inner_color = 2131427382;
+			// aapt resource value: 0x7f0c0036
+			public const int fab_stroke_top_inner_color = 2131492918;
 			
-			// aapt resource value: 0x7f0b0037
-			public const int fab_stroke_top_outer_color = 2131427383;
+			// aapt resource value: 0x7f0c0037
+			public const int fab_stroke_top_outer_color = 2131492919;
 			
-			// aapt resource value: 0x7f0b0016
-			public const int highlighted_text_material_dark = 2131427350;
+			// aapt resource value: 0x7f0c0016
+			public const int highlighted_text_material_dark = 2131492886;
 			
-			// aapt resource value: 0x7f0b0017
-			public const int highlighted_text_material_light = 2131427351;
+			// aapt resource value: 0x7f0c0017
+			public const int highlighted_text_material_light = 2131492887;
 			
-			// aapt resource value: 0x7f0b0018
-			public const int hint_foreground_material_dark = 2131427352;
+			// aapt resource value: 0x7f0c0018
+			public const int hint_foreground_material_dark = 2131492888;
 			
-			// aapt resource value: 0x7f0b0019
-			public const int hint_foreground_material_light = 2131427353;
+			// aapt resource value: 0x7f0c0019
+			public const int hint_foreground_material_light = 2131492889;
 			
-			// aapt resource value: 0x7f0b001a
-			public const int link_text_material_dark = 2131427354;
+			// aapt resource value: 0x7f0c001a
+			public const int link_text_material_dark = 2131492890;
 			
-			// aapt resource value: 0x7f0b001b
-			public const int link_text_material_light = 2131427355;
+			// aapt resource value: 0x7f0c001b
+			public const int link_text_material_light = 2131492891;
 			
-			// aapt resource value: 0x7f0b001c
-			public const int material_blue_grey_800 = 2131427356;
+			// aapt resource value: 0x7f0c001c
+			public const int material_blue_grey_800 = 2131492892;
 			
-			// aapt resource value: 0x7f0b001d
-			public const int material_blue_grey_900 = 2131427357;
+			// aapt resource value: 0x7f0c001d
+			public const int material_blue_grey_900 = 2131492893;
 			
-			// aapt resource value: 0x7f0b001e
-			public const int material_blue_grey_950 = 2131427358;
+			// aapt resource value: 0x7f0c001e
+			public const int material_blue_grey_950 = 2131492894;
 			
-			// aapt resource value: 0x7f0b001f
-			public const int material_deep_teal_200 = 2131427359;
+			// aapt resource value: 0x7f0c001f
+			public const int material_deep_teal_200 = 2131492895;
 			
-			// aapt resource value: 0x7f0b0020
-			public const int material_deep_teal_500 = 2131427360;
+			// aapt resource value: 0x7f0c0020
+			public const int material_deep_teal_500 = 2131492896;
 			
-			// aapt resource value: 0x7f0b0021
-			public const int primary_dark_material_dark = 2131427361;
+			// aapt resource value: 0x7f0c0021
+			public const int primary_dark_material_dark = 2131492897;
 			
-			// aapt resource value: 0x7f0b0022
-			public const int primary_dark_material_light = 2131427362;
+			// aapt resource value: 0x7f0c0022
+			public const int primary_dark_material_light = 2131492898;
 			
-			// aapt resource value: 0x7f0b0023
-			public const int primary_material_dark = 2131427363;
+			// aapt resource value: 0x7f0c0023
+			public const int primary_material_dark = 2131492899;
 			
-			// aapt resource value: 0x7f0b0024
-			public const int primary_material_light = 2131427364;
+			// aapt resource value: 0x7f0c0024
+			public const int primary_material_light = 2131492900;
 			
-			// aapt resource value: 0x7f0b0025
-			public const int primary_text_default_material_dark = 2131427365;
+			// aapt resource value: 0x7f0c0025
+			public const int primary_text_default_material_dark = 2131492901;
 			
-			// aapt resource value: 0x7f0b0026
-			public const int primary_text_default_material_light = 2131427366;
+			// aapt resource value: 0x7f0c0026
+			public const int primary_text_default_material_light = 2131492902;
 			
-			// aapt resource value: 0x7f0b0027
-			public const int primary_text_disabled_material_dark = 2131427367;
+			// aapt resource value: 0x7f0c0027
+			public const int primary_text_disabled_material_dark = 2131492903;
 			
-			// aapt resource value: 0x7f0b0028
-			public const int primary_text_disabled_material_light = 2131427368;
+			// aapt resource value: 0x7f0c0028
+			public const int primary_text_disabled_material_light = 2131492904;
 			
-			// aapt resource value: 0x7f0b0029
-			public const int ripple_material_dark = 2131427369;
+			// aapt resource value: 0x7f0c0029
+			public const int ripple_material_dark = 2131492905;
 			
-			// aapt resource value: 0x7f0b002a
-			public const int ripple_material_light = 2131427370;
+			// aapt resource value: 0x7f0c002a
+			public const int ripple_material_light = 2131492906;
 			
-			// aapt resource value: 0x7f0b002b
-			public const int secondary_text_default_material_dark = 2131427371;
+			// aapt resource value: 0x7f0c002b
+			public const int secondary_text_default_material_dark = 2131492907;
 			
-			// aapt resource value: 0x7f0b002c
-			public const int secondary_text_default_material_light = 2131427372;
+			// aapt resource value: 0x7f0c002c
+			public const int secondary_text_default_material_light = 2131492908;
 			
-			// aapt resource value: 0x7f0b002d
-			public const int secondary_text_disabled_material_dark = 2131427373;
+			// aapt resource value: 0x7f0c002d
+			public const int secondary_text_disabled_material_dark = 2131492909;
 			
-			// aapt resource value: 0x7f0b002e
-			public const int secondary_text_disabled_material_light = 2131427374;
+			// aapt resource value: 0x7f0c002e
+			public const int secondary_text_disabled_material_light = 2131492910;
 			
-			// aapt resource value: 0x7f0b0038
-			public const int shadow_end_color = 2131427384;
+			// aapt resource value: 0x7f0c0038
+			public const int shadow_end_color = 2131492920;
 			
-			// aapt resource value: 0x7f0b0039
-			public const int shadow_mid_color = 2131427385;
+			// aapt resource value: 0x7f0c0039
+			public const int shadow_mid_color = 2131492921;
 			
-			// aapt resource value: 0x7f0b003a
-			public const int shadow_start_color = 2131427386;
+			// aapt resource value: 0x7f0c003a
+			public const int shadow_start_color = 2131492922;
 			
-			// aapt resource value: 0x7f0b003b
-			public const int snackbar_background_color = 2131427387;
+			// aapt resource value: 0x7f0c003b
+			public const int snackbar_background_color = 2131492923;
 			
-			// aapt resource value: 0x7f0b002f
-			public const int switch_thumb_disabled_material_dark = 2131427375;
+			// aapt resource value: 0x7f0c002f
+			public const int switch_thumb_disabled_material_dark = 2131492911;
 			
-			// aapt resource value: 0x7f0b0030
-			public const int switch_thumb_disabled_material_light = 2131427376;
+			// aapt resource value: 0x7f0c0030
+			public const int switch_thumb_disabled_material_light = 2131492912;
 			
-			// aapt resource value: 0x7f0b004a
-			public const int switch_thumb_material_dark = 2131427402;
+			// aapt resource value: 0x7f0c004a
+			public const int switch_thumb_material_dark = 2131492938;
 			
-			// aapt resource value: 0x7f0b004b
-			public const int switch_thumb_material_light = 2131427403;
+			// aapt resource value: 0x7f0c004b
+			public const int switch_thumb_material_light = 2131492939;
 			
-			// aapt resource value: 0x7f0b0031
-			public const int switch_thumb_normal_material_dark = 2131427377;
+			// aapt resource value: 0x7f0c0031
+			public const int switch_thumb_normal_material_dark = 2131492913;
 			
-			// aapt resource value: 0x7f0b0032
-			public const int switch_thumb_normal_material_light = 2131427378;
+			// aapt resource value: 0x7f0c0032
+			public const int switch_thumb_normal_material_light = 2131492914;
 			
-			// aapt resource value: 0x7f0b003f
-			public const int white = 2131427391;
+			// aapt resource value: 0x7f0c003f
+			public const int white = 2131492927;
 			
 			static Color()
 			{
@@ -1184,293 +1184,293 @@ namespace Example.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f05000d
-			public const int abc_action_bar_content_inset_material = 2131034125;
+			// aapt resource value: 0x7f06000d
+			public const int abc_action_bar_content_inset_material = 2131099661;
 			
-			// aapt resource value: 0x7f050002
-			public const int abc_action_bar_default_height_material = 2131034114;
+			// aapt resource value: 0x7f060002
+			public const int abc_action_bar_default_height_material = 2131099650;
 			
-			// aapt resource value: 0x7f050003
-			public const int abc_action_bar_default_padding_material = 2131034115;
+			// aapt resource value: 0x7f060003
+			public const int abc_action_bar_default_padding_material = 2131099651;
 			
-			// aapt resource value: 0x7f050011
-			public const int abc_action_bar_icon_vertical_padding_material = 2131034129;
+			// aapt resource value: 0x7f060011
+			public const int abc_action_bar_icon_vertical_padding_material = 2131099665;
 			
-			// aapt resource value: 0x7f05000e
-			public const int abc_action_bar_navigation_padding_start_material = 2131034126;
+			// aapt resource value: 0x7f06000e
+			public const int abc_action_bar_navigation_padding_start_material = 2131099662;
 			
-			// aapt resource value: 0x7f05000f
-			public const int abc_action_bar_overflow_padding_end_material = 2131034127;
+			// aapt resource value: 0x7f06000f
+			public const int abc_action_bar_overflow_padding_end_material = 2131099663;
 			
-			// aapt resource value: 0x7f050012
-			public const int abc_action_bar_overflow_padding_start_material = 2131034130;
+			// aapt resource value: 0x7f060012
+			public const int abc_action_bar_overflow_padding_start_material = 2131099666;
 			
-			// aapt resource value: 0x7f050004
-			public const int abc_action_bar_progress_bar_size = 2131034116;
+			// aapt resource value: 0x7f060004
+			public const int abc_action_bar_progress_bar_size = 2131099652;
 			
-			// aapt resource value: 0x7f050013
-			public const int abc_action_bar_stacked_max_height = 2131034131;
+			// aapt resource value: 0x7f060013
+			public const int abc_action_bar_stacked_max_height = 2131099667;
 			
-			// aapt resource value: 0x7f050014
-			public const int abc_action_bar_stacked_tab_max_width = 2131034132;
+			// aapt resource value: 0x7f060014
+			public const int abc_action_bar_stacked_tab_max_width = 2131099668;
 			
-			// aapt resource value: 0x7f050015
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131034133;
+			// aapt resource value: 0x7f060015
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099669;
 			
-			// aapt resource value: 0x7f050016
-			public const int abc_action_bar_subtitle_top_margin_material = 2131034134;
+			// aapt resource value: 0x7f060016
+			public const int abc_action_bar_subtitle_top_margin_material = 2131099670;
 			
-			// aapt resource value: 0x7f050017
-			public const int abc_action_button_min_height_material = 2131034135;
+			// aapt resource value: 0x7f060017
+			public const int abc_action_button_min_height_material = 2131099671;
 			
-			// aapt resource value: 0x7f050018
-			public const int abc_action_button_min_width_material = 2131034136;
+			// aapt resource value: 0x7f060018
+			public const int abc_action_button_min_width_material = 2131099672;
 			
-			// aapt resource value: 0x7f050019
-			public const int abc_action_button_min_width_overflow_material = 2131034137;
+			// aapt resource value: 0x7f060019
+			public const int abc_action_button_min_width_overflow_material = 2131099673;
 			
-			// aapt resource value: 0x7f050001
-			public const int abc_alert_dialog_button_bar_height = 2131034113;
+			// aapt resource value: 0x7f060001
+			public const int abc_alert_dialog_button_bar_height = 2131099649;
 			
-			// aapt resource value: 0x7f05001a
-			public const int abc_button_inset_horizontal_material = 2131034138;
+			// aapt resource value: 0x7f06001a
+			public const int abc_button_inset_horizontal_material = 2131099674;
 			
-			// aapt resource value: 0x7f05001b
-			public const int abc_button_inset_vertical_material = 2131034139;
+			// aapt resource value: 0x7f06001b
+			public const int abc_button_inset_vertical_material = 2131099675;
 			
-			// aapt resource value: 0x7f05001c
-			public const int abc_button_padding_horizontal_material = 2131034140;
+			// aapt resource value: 0x7f06001c
+			public const int abc_button_padding_horizontal_material = 2131099676;
 			
-			// aapt resource value: 0x7f05001d
-			public const int abc_button_padding_vertical_material = 2131034141;
+			// aapt resource value: 0x7f06001d
+			public const int abc_button_padding_vertical_material = 2131099677;
 			
-			// aapt resource value: 0x7f050007
-			public const int abc_config_prefDialogWidth = 2131034119;
+			// aapt resource value: 0x7f060007
+			public const int abc_config_prefDialogWidth = 2131099655;
 			
-			// aapt resource value: 0x7f05001e
-			public const int abc_control_corner_material = 2131034142;
+			// aapt resource value: 0x7f06001e
+			public const int abc_control_corner_material = 2131099678;
 			
-			// aapt resource value: 0x7f05001f
-			public const int abc_control_inset_material = 2131034143;
+			// aapt resource value: 0x7f06001f
+			public const int abc_control_inset_material = 2131099679;
 			
-			// aapt resource value: 0x7f050020
-			public const int abc_control_padding_material = 2131034144;
+			// aapt resource value: 0x7f060020
+			public const int abc_control_padding_material = 2131099680;
 			
-			// aapt resource value: 0x7f050021
-			public const int abc_dialog_list_padding_vertical_material = 2131034145;
+			// aapt resource value: 0x7f060021
+			public const int abc_dialog_list_padding_vertical_material = 2131099681;
 			
-			// aapt resource value: 0x7f050022
-			public const int abc_dialog_min_width_major = 2131034146;
+			// aapt resource value: 0x7f060022
+			public const int abc_dialog_min_width_major = 2131099682;
 			
-			// aapt resource value: 0x7f050023
-			public const int abc_dialog_min_width_minor = 2131034147;
+			// aapt resource value: 0x7f060023
+			public const int abc_dialog_min_width_minor = 2131099683;
 			
-			// aapt resource value: 0x7f050024
-			public const int abc_dialog_padding_material = 2131034148;
+			// aapt resource value: 0x7f060024
+			public const int abc_dialog_padding_material = 2131099684;
 			
-			// aapt resource value: 0x7f050025
-			public const int abc_dialog_padding_top_material = 2131034149;
+			// aapt resource value: 0x7f060025
+			public const int abc_dialog_padding_top_material = 2131099685;
 			
-			// aapt resource value: 0x7f050026
-			public const int abc_disabled_alpha_material_dark = 2131034150;
+			// aapt resource value: 0x7f060026
+			public const int abc_disabled_alpha_material_dark = 2131099686;
 			
-			// aapt resource value: 0x7f050027
-			public const int abc_disabled_alpha_material_light = 2131034151;
+			// aapt resource value: 0x7f060027
+			public const int abc_disabled_alpha_material_light = 2131099687;
 			
-			// aapt resource value: 0x7f050028
-			public const int abc_dropdownitem_icon_width = 2131034152;
+			// aapt resource value: 0x7f060028
+			public const int abc_dropdownitem_icon_width = 2131099688;
 			
-			// aapt resource value: 0x7f050029
-			public const int abc_dropdownitem_text_padding_left = 2131034153;
+			// aapt resource value: 0x7f060029
+			public const int abc_dropdownitem_text_padding_left = 2131099689;
 			
-			// aapt resource value: 0x7f05002a
-			public const int abc_dropdownitem_text_padding_right = 2131034154;
+			// aapt resource value: 0x7f06002a
+			public const int abc_dropdownitem_text_padding_right = 2131099690;
 			
-			// aapt resource value: 0x7f05002b
-			public const int abc_edit_text_inset_bottom_material = 2131034155;
+			// aapt resource value: 0x7f06002b
+			public const int abc_edit_text_inset_bottom_material = 2131099691;
 			
-			// aapt resource value: 0x7f05002c
-			public const int abc_edit_text_inset_horizontal_material = 2131034156;
+			// aapt resource value: 0x7f06002c
+			public const int abc_edit_text_inset_horizontal_material = 2131099692;
 			
-			// aapt resource value: 0x7f05002d
-			public const int abc_edit_text_inset_top_material = 2131034157;
+			// aapt resource value: 0x7f06002d
+			public const int abc_edit_text_inset_top_material = 2131099693;
 			
-			// aapt resource value: 0x7f05002e
-			public const int abc_floating_window_z = 2131034158;
+			// aapt resource value: 0x7f06002e
+			public const int abc_floating_window_z = 2131099694;
 			
-			// aapt resource value: 0x7f05002f
-			public const int abc_list_item_padding_horizontal_material = 2131034159;
+			// aapt resource value: 0x7f06002f
+			public const int abc_list_item_padding_horizontal_material = 2131099695;
 			
-			// aapt resource value: 0x7f050030
-			public const int abc_panel_menu_list_width = 2131034160;
+			// aapt resource value: 0x7f060030
+			public const int abc_panel_menu_list_width = 2131099696;
 			
-			// aapt resource value: 0x7f050031
-			public const int abc_search_view_preferred_width = 2131034161;
+			// aapt resource value: 0x7f060031
+			public const int abc_search_view_preferred_width = 2131099697;
 			
-			// aapt resource value: 0x7f050008
-			public const int abc_search_view_text_min_width = 2131034120;
+			// aapt resource value: 0x7f060008
+			public const int abc_search_view_text_min_width = 2131099656;
 			
-			// aapt resource value: 0x7f050010
-			public const int abc_switch_padding = 2131034128;
+			// aapt resource value: 0x7f060010
+			public const int abc_switch_padding = 2131099664;
 			
-			// aapt resource value: 0x7f050032
-			public const int abc_text_size_body_1_material = 2131034162;
+			// aapt resource value: 0x7f060032
+			public const int abc_text_size_body_1_material = 2131099698;
 			
-			// aapt resource value: 0x7f050033
-			public const int abc_text_size_body_2_material = 2131034163;
+			// aapt resource value: 0x7f060033
+			public const int abc_text_size_body_2_material = 2131099699;
 			
-			// aapt resource value: 0x7f050034
-			public const int abc_text_size_button_material = 2131034164;
+			// aapt resource value: 0x7f060034
+			public const int abc_text_size_button_material = 2131099700;
 			
-			// aapt resource value: 0x7f050035
-			public const int abc_text_size_caption_material = 2131034165;
+			// aapt resource value: 0x7f060035
+			public const int abc_text_size_caption_material = 2131099701;
 			
-			// aapt resource value: 0x7f050036
-			public const int abc_text_size_display_1_material = 2131034166;
+			// aapt resource value: 0x7f060036
+			public const int abc_text_size_display_1_material = 2131099702;
 			
-			// aapt resource value: 0x7f050037
-			public const int abc_text_size_display_2_material = 2131034167;
+			// aapt resource value: 0x7f060037
+			public const int abc_text_size_display_2_material = 2131099703;
 			
-			// aapt resource value: 0x7f050038
-			public const int abc_text_size_display_3_material = 2131034168;
+			// aapt resource value: 0x7f060038
+			public const int abc_text_size_display_3_material = 2131099704;
 			
-			// aapt resource value: 0x7f050039
-			public const int abc_text_size_display_4_material = 2131034169;
+			// aapt resource value: 0x7f060039
+			public const int abc_text_size_display_4_material = 2131099705;
 			
-			// aapt resource value: 0x7f05003a
-			public const int abc_text_size_headline_material = 2131034170;
+			// aapt resource value: 0x7f06003a
+			public const int abc_text_size_headline_material = 2131099706;
 			
-			// aapt resource value: 0x7f05003b
-			public const int abc_text_size_large_material = 2131034171;
+			// aapt resource value: 0x7f06003b
+			public const int abc_text_size_large_material = 2131099707;
 			
-			// aapt resource value: 0x7f05003c
-			public const int abc_text_size_medium_material = 2131034172;
+			// aapt resource value: 0x7f06003c
+			public const int abc_text_size_medium_material = 2131099708;
 			
-			// aapt resource value: 0x7f05003d
-			public const int abc_text_size_menu_material = 2131034173;
+			// aapt resource value: 0x7f06003d
+			public const int abc_text_size_menu_material = 2131099709;
 			
-			// aapt resource value: 0x7f05003e
-			public const int abc_text_size_small_material = 2131034174;
+			// aapt resource value: 0x7f06003e
+			public const int abc_text_size_small_material = 2131099710;
 			
-			// aapt resource value: 0x7f05003f
-			public const int abc_text_size_subhead_material = 2131034175;
+			// aapt resource value: 0x7f06003f
+			public const int abc_text_size_subhead_material = 2131099711;
 			
-			// aapt resource value: 0x7f050005
-			public const int abc_text_size_subtitle_material_toolbar = 2131034117;
+			// aapt resource value: 0x7f060005
+			public const int abc_text_size_subtitle_material_toolbar = 2131099653;
 			
-			// aapt resource value: 0x7f050040
-			public const int abc_text_size_title_material = 2131034176;
+			// aapt resource value: 0x7f060040
+			public const int abc_text_size_title_material = 2131099712;
 			
-			// aapt resource value: 0x7f050006
-			public const int abc_text_size_title_material_toolbar = 2131034118;
+			// aapt resource value: 0x7f060006
+			public const int abc_text_size_title_material_toolbar = 2131099654;
 			
-			// aapt resource value: 0x7f05004e
-			public const int appbar_elevation = 2131034190;
+			// aapt resource value: 0x7f06004e
+			public const int appbar_elevation = 2131099726;
 			
-			// aapt resource value: 0x7f050009
-			public const int dialog_fixed_height_major = 2131034121;
+			// aapt resource value: 0x7f060009
+			public const int dialog_fixed_height_major = 2131099657;
 			
-			// aapt resource value: 0x7f05000a
-			public const int dialog_fixed_height_minor = 2131034122;
+			// aapt resource value: 0x7f06000a
+			public const int dialog_fixed_height_minor = 2131099658;
 			
-			// aapt resource value: 0x7f05000b
-			public const int dialog_fixed_width_major = 2131034123;
+			// aapt resource value: 0x7f06000b
+			public const int dialog_fixed_width_major = 2131099659;
 			
-			// aapt resource value: 0x7f05000c
-			public const int dialog_fixed_width_minor = 2131034124;
+			// aapt resource value: 0x7f06000c
+			public const int dialog_fixed_width_minor = 2131099660;
 			
-			// aapt resource value: 0x7f050041
-			public const int disabled_alpha_material_dark = 2131034177;
+			// aapt resource value: 0x7f060041
+			public const int disabled_alpha_material_dark = 2131099713;
 			
-			// aapt resource value: 0x7f050042
-			public const int disabled_alpha_material_light = 2131034178;
+			// aapt resource value: 0x7f060042
+			public const int disabled_alpha_material_light = 2131099714;
 			
-			// aapt resource value: 0x7f05004f
-			public const int fab_border_width = 2131034191;
+			// aapt resource value: 0x7f06004f
+			public const int fab_border_width = 2131099727;
 			
-			// aapt resource value: 0x7f050050
-			public const int fab_content_size = 2131034192;
+			// aapt resource value: 0x7f060050
+			public const int fab_content_size = 2131099728;
 			
-			// aapt resource value: 0x7f050051
-			public const int fab_elevation = 2131034193;
+			// aapt resource value: 0x7f060051
+			public const int fab_elevation = 2131099729;
 			
-			// aapt resource value: 0x7f050052
-			public const int fab_size_mini = 2131034194;
+			// aapt resource value: 0x7f060052
+			public const int fab_size_mini = 2131099730;
 			
-			// aapt resource value: 0x7f050053
-			public const int fab_size_normal = 2131034195;
+			// aapt resource value: 0x7f060053
+			public const int fab_size_normal = 2131099731;
 			
-			// aapt resource value: 0x7f050054
-			public const int fab_translation_z_pressed = 2131034196;
+			// aapt resource value: 0x7f060054
+			public const int fab_translation_z_pressed = 2131099732;
 			
-			// aapt resource value: 0x7f050000
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131034112;
+			// aapt resource value: 0x7f060000
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099648;
 			
-			// aapt resource value: 0x7f050055
-			public const int navigation_elevation = 2131034197;
+			// aapt resource value: 0x7f060055
+			public const int navigation_elevation = 2131099733;
 			
-			// aapt resource value: 0x7f050056
-			public const int navigation_icon_padding = 2131034198;
+			// aapt resource value: 0x7f060056
+			public const int navigation_icon_padding = 2131099734;
 			
-			// aapt resource value: 0x7f050057
-			public const int navigation_icon_size = 2131034199;
+			// aapt resource value: 0x7f060057
+			public const int navigation_icon_size = 2131099735;
 			
-			// aapt resource value: 0x7f050058
-			public const int navigation_max_width = 2131034200;
+			// aapt resource value: 0x7f060058
+			public const int navigation_max_width = 2131099736;
 			
-			// aapt resource value: 0x7f050059
-			public const int navigation_padding_bottom = 2131034201;
+			// aapt resource value: 0x7f060059
+			public const int navigation_padding_bottom = 2131099737;
 			
-			// aapt resource value: 0x7f05004d
-			public const int navigation_padding_top_default = 2131034189;
+			// aapt resource value: 0x7f06004d
+			public const int navigation_padding_top_default = 2131099725;
 			
-			// aapt resource value: 0x7f05005a
-			public const int navigation_separator_vertical_padding = 2131034202;
+			// aapt resource value: 0x7f06005a
+			public const int navigation_separator_vertical_padding = 2131099738;
 			
-			// aapt resource value: 0x7f050043
-			public const int notification_large_icon_height = 2131034179;
+			// aapt resource value: 0x7f060043
+			public const int notification_large_icon_height = 2131099715;
 			
-			// aapt resource value: 0x7f050044
-			public const int notification_large_icon_width = 2131034180;
+			// aapt resource value: 0x7f060044
+			public const int notification_large_icon_width = 2131099716;
 			
-			// aapt resource value: 0x7f050045
-			public const int notification_subtext_size = 2131034181;
+			// aapt resource value: 0x7f060045
+			public const int notification_subtext_size = 2131099717;
 			
-			// aapt resource value: 0x7f050046
-			public const int snackbar_action_inline_max_width = 2131034182;
+			// aapt resource value: 0x7f060046
+			public const int snackbar_action_inline_max_width = 2131099718;
 			
-			// aapt resource value: 0x7f050047
-			public const int snackbar_background_corner_radius = 2131034183;
+			// aapt resource value: 0x7f060047
+			public const int snackbar_background_corner_radius = 2131099719;
 			
-			// aapt resource value: 0x7f05005b
-			public const int snackbar_elevation = 2131034203;
+			// aapt resource value: 0x7f06005b
+			public const int snackbar_elevation = 2131099739;
 			
-			// aapt resource value: 0x7f050048
-			public const int snackbar_extra_spacing_horizontal = 2131034184;
+			// aapt resource value: 0x7f060048
+			public const int snackbar_extra_spacing_horizontal = 2131099720;
 			
-			// aapt resource value: 0x7f050049
-			public const int snackbar_max_width = 2131034185;
+			// aapt resource value: 0x7f060049
+			public const int snackbar_max_width = 2131099721;
 			
-			// aapt resource value: 0x7f05004a
-			public const int snackbar_min_width = 2131034186;
+			// aapt resource value: 0x7f06004a
+			public const int snackbar_min_width = 2131099722;
 			
-			// aapt resource value: 0x7f05005c
-			public const int snackbar_padding_horizontal = 2131034204;
+			// aapt resource value: 0x7f06005c
+			public const int snackbar_padding_horizontal = 2131099740;
 			
-			// aapt resource value: 0x7f05005d
-			public const int snackbar_padding_vertical = 2131034205;
+			// aapt resource value: 0x7f06005d
+			public const int snackbar_padding_vertical = 2131099741;
 			
-			// aapt resource value: 0x7f05004b
-			public const int snackbar_padding_vertical_2lines = 2131034187;
+			// aapt resource value: 0x7f06004b
+			public const int snackbar_padding_vertical_2lines = 2131099723;
 			
-			// aapt resource value: 0x7f05005e
-			public const int snackbar_text_size = 2131034206;
+			// aapt resource value: 0x7f06005e
+			public const int snackbar_text_size = 2131099742;
 			
-			// aapt resource value: 0x7f05005f
-			public const int tab_max_width = 2131034207;
+			// aapt resource value: 0x7f06005f
+			public const int tab_max_width = 2131099743;
 			
-			// aapt resource value: 0x7f05004c
-			public const int tab_min_width = 2131034188;
+			// aapt resource value: 0x7f06004c
+			public const int tab_min_width = 2131099724;
 			
 			static Dimension()
 			{
@@ -1668,14 +1668,17 @@ namespace Example.Droid
 			// aapt resource value: 0x7f02003c
 			public const int Icon = 2130837564;
 			
-			// aapt resource value: 0x7f02003f
-			public const int notification_template_icon_bg = 2130837567;
-			
 			// aapt resource value: 0x7f02003d
-			public const int snackbar_background = 2130837565;
+			public const int monoandroidsplash = 2130837565;
+			
+			// aapt resource value: 0x7f020040
+			public const int notification_template_icon_bg = 2130837568;
 			
 			// aapt resource value: 0x7f02003e
-			public const int splash = 2130837566;
+			public const int snackbar_background = 2130837566;
+			
+			// aapt resource value: 0x7f02003f
+			public const int splash = 2130837567;
 			
 			static Drawable()
 			{
@@ -1690,419 +1693,419 @@ namespace Example.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f06000b
-			public const int MvvmCrossTagId = 2131099659;
+			// aapt resource value: 0x7f07000b
+			public const int MvvmCrossTagId = 2131165195;
 			
-			// aapt resource value: 0x7f06000c
-			public const int MvxBindingTagUnique = 2131099660;
+			// aapt resource value: 0x7f07000c
+			public const int MvxBindingTagUnique = 2131165196;
 			
-			// aapt resource value: 0x7f060078
-			public const int action0 = 2131099768;
+			// aapt resource value: 0x7f070078
+			public const int action0 = 2131165304;
 			
-			// aapt resource value: 0x7f06005a
-			public const int action_bar = 2131099738;
+			// aapt resource value: 0x7f07005a
+			public const int action_bar = 2131165274;
 			
-			// aapt resource value: 0x7f060001
-			public const int action_bar_activity_content = 2131099649;
+			// aapt resource value: 0x7f070001
+			public const int action_bar_activity_content = 2131165185;
 			
-			// aapt resource value: 0x7f060059
-			public const int action_bar_container = 2131099737;
+			// aapt resource value: 0x7f070059
+			public const int action_bar_container = 2131165273;
 			
-			// aapt resource value: 0x7f060055
-			public const int action_bar_root = 2131099733;
+			// aapt resource value: 0x7f070055
+			public const int action_bar_root = 2131165269;
 			
-			// aapt resource value: 0x7f060002
-			public const int action_bar_spinner = 2131099650;
+			// aapt resource value: 0x7f070002
+			public const int action_bar_spinner = 2131165186;
 			
-			// aapt resource value: 0x7f06003e
-			public const int action_bar_subtitle = 2131099710;
+			// aapt resource value: 0x7f07003e
+			public const int action_bar_subtitle = 2131165246;
 			
-			// aapt resource value: 0x7f06003d
-			public const int action_bar_title = 2131099709;
+			// aapt resource value: 0x7f07003d
+			public const int action_bar_title = 2131165245;
 			
-			// aapt resource value: 0x7f06005b
-			public const int action_context_bar = 2131099739;
+			// aapt resource value: 0x7f07005b
+			public const int action_context_bar = 2131165275;
 			
-			// aapt resource value: 0x7f06007c
-			public const int action_divider = 2131099772;
+			// aapt resource value: 0x7f07007c
+			public const int action_divider = 2131165308;
 			
-			// aapt resource value: 0x7f060003
-			public const int action_menu_divider = 2131099651;
+			// aapt resource value: 0x7f070003
+			public const int action_menu_divider = 2131165187;
 			
-			// aapt resource value: 0x7f060004
-			public const int action_menu_presenter = 2131099652;
+			// aapt resource value: 0x7f070004
+			public const int action_menu_presenter = 2131165188;
 			
-			// aapt resource value: 0x7f060057
-			public const int action_mode_bar = 2131099735;
+			// aapt resource value: 0x7f070057
+			public const int action_mode_bar = 2131165271;
 			
-			// aapt resource value: 0x7f060056
-			public const int action_mode_bar_stub = 2131099734;
+			// aapt resource value: 0x7f070056
+			public const int action_mode_bar_stub = 2131165270;
 			
-			// aapt resource value: 0x7f06003f
-			public const int action_mode_close_button = 2131099711;
+			// aapt resource value: 0x7f07003f
+			public const int action_mode_close_button = 2131165247;
 			
-			// aapt resource value: 0x7f060040
-			public const int activity_chooser_view_content = 2131099712;
+			// aapt resource value: 0x7f070040
+			public const int activity_chooser_view_content = 2131165248;
 			
-			// aapt resource value: 0x7f06004a
-			public const int alertTitle = 2131099722;
+			// aapt resource value: 0x7f07004a
+			public const int alertTitle = 2131165258;
 			
-			// aapt resource value: 0x7f06001a
-			public const int always = 2131099674;
+			// aapt resource value: 0x7f07001a
+			public const int always = 2131165210;
 			
-			// aapt resource value: 0x7f06006d
-			public const int appbar = 2131099757;
+			// aapt resource value: 0x7f07006d
+			public const int appbar = 2131165293;
 			
-			// aapt resource value: 0x7f060017
-			public const int beginning = 2131099671;
+			// aapt resource value: 0x7f070017
+			public const int beginning = 2131165207;
 			
-			// aapt resource value: 0x7f06002d
-			public const int bottom = 2131099693;
+			// aapt resource value: 0x7f07002d
+			public const int bottom = 2131165229;
 			
-			// aapt resource value: 0x7f060050
-			public const int buttonPanel = 2131099728;
+			// aapt resource value: 0x7f070050
+			public const int buttonPanel = 2131165264;
 			
-			// aapt resource value: 0x7f060079
-			public const int cancel_action = 2131099769;
+			// aapt resource value: 0x7f070079
+			public const int cancel_action = 2131165305;
 			
-			// aapt resource value: 0x7f06002e
-			public const int center = 2131099694;
+			// aapt resource value: 0x7f07002e
+			public const int center = 2131165230;
 			
-			// aapt resource value: 0x7f06002f
-			public const int center_horizontal = 2131099695;
+			// aapt resource value: 0x7f07002f
+			public const int center_horizontal = 2131165231;
 			
-			// aapt resource value: 0x7f060030
-			public const int center_vertical = 2131099696;
+			// aapt resource value: 0x7f070030
+			public const int center_vertical = 2131165232;
 			
-			// aapt resource value: 0x7f060052
-			public const int checkbox = 2131099730;
+			// aapt resource value: 0x7f070052
+			public const int checkbox = 2131165266;
 			
-			// aapt resource value: 0x7f06007f
-			public const int chronometer = 2131099775;
+			// aapt resource value: 0x7f07007f
+			public const int chronometer = 2131165311;
 			
-			// aapt resource value: 0x7f060031
-			public const int clip_horizontal = 2131099697;
+			// aapt resource value: 0x7f070031
+			public const int clip_horizontal = 2131165233;
 			
-			// aapt resource value: 0x7f060032
-			public const int clip_vertical = 2131099698;
+			// aapt resource value: 0x7f070032
+			public const int clip_vertical = 2131165234;
 			
-			// aapt resource value: 0x7f06001b
-			public const int collapseActionView = 2131099675;
+			// aapt resource value: 0x7f07001b
+			public const int collapseActionView = 2131165211;
 			
-			// aapt resource value: 0x7f06004b
-			public const int contentPanel = 2131099723;
+			// aapt resource value: 0x7f07004b
+			public const int contentPanel = 2131165259;
 			
-			// aapt resource value: 0x7f06006a
-			public const int content_frame = 2131099754;
+			// aapt resource value: 0x7f07006a
+			public const int content_frame = 2131165290;
 			
-			// aapt resource value: 0x7f06004f
-			public const int custom = 2131099727;
+			// aapt resource value: 0x7f07004f
+			public const int custom = 2131165263;
 			
-			// aapt resource value: 0x7f06004e
-			public const int customPanel = 2131099726;
+			// aapt resource value: 0x7f07004e
+			public const int customPanel = 2131165262;
 			
-			// aapt resource value: 0x7f060058
-			public const int decor_content_parent = 2131099736;
+			// aapt resource value: 0x7f070058
+			public const int decor_content_parent = 2131165272;
 			
-			// aapt resource value: 0x7f060043
-			public const int default_activity_button = 2131099715;
+			// aapt resource value: 0x7f070043
+			public const int default_activity_button = 2131165251;
 			
-			// aapt resource value: 0x7f06001f
-			public const int dialog = 2131099679;
+			// aapt resource value: 0x7f07001f
+			public const int dialog = 2131165215;
 			
-			// aapt resource value: 0x7f060010
-			public const int disableHome = 2131099664;
+			// aapt resource value: 0x7f070010
+			public const int disableHome = 2131165200;
 			
-			// aapt resource value: 0x7f060069
-			public const int drawer_layout = 2131099753;
+			// aapt resource value: 0x7f070069
+			public const int drawer_layout = 2131165289;
 			
-			// aapt resource value: 0x7f060020
-			public const int dropdown = 2131099680;
+			// aapt resource value: 0x7f070020
+			public const int dropdown = 2131165216;
 			
-			// aapt resource value: 0x7f06005c
-			public const int edit_query = 2131099740;
+			// aapt resource value: 0x7f07005c
+			public const int edit_query = 2131165276;
 			
-			// aapt resource value: 0x7f060018
-			public const int end = 2131099672;
+			// aapt resource value: 0x7f070018
+			public const int end = 2131165208;
 			
-			// aapt resource value: 0x7f060084
-			public const int end_padder = 2131099780;
+			// aapt resource value: 0x7f070084
+			public const int end_padder = 2131165316;
 			
-			// aapt resource value: 0x7f060027
-			public const int enterAlways = 2131099687;
+			// aapt resource value: 0x7f070027
+			public const int enterAlways = 2131165223;
 			
-			// aapt resource value: 0x7f060028
-			public const int enterAlwaysCollapsed = 2131099688;
+			// aapt resource value: 0x7f070028
+			public const int enterAlwaysCollapsed = 2131165224;
 			
-			// aapt resource value: 0x7f060029
-			public const int exitUntilCollapsed = 2131099689;
+			// aapt resource value: 0x7f070029
+			public const int exitUntilCollapsed = 2131165225;
 			
-			// aapt resource value: 0x7f060041
-			public const int expand_activities_button = 2131099713;
+			// aapt resource value: 0x7f070041
+			public const int expand_activities_button = 2131165249;
 			
-			// aapt resource value: 0x7f060051
-			public const int expanded_menu = 2131099729;
+			// aapt resource value: 0x7f070051
+			public const int expanded_menu = 2131165265;
 			
-			// aapt resource value: 0x7f060033
-			public const int fill = 2131099699;
+			// aapt resource value: 0x7f070033
+			public const int fill = 2131165235;
 			
-			// aapt resource value: 0x7f060034
-			public const int fill_horizontal = 2131099700;
+			// aapt resource value: 0x7f070034
+			public const int fill_horizontal = 2131165236;
 			
-			// aapt resource value: 0x7f060035
-			public const int fill_vertical = 2131099701;
+			// aapt resource value: 0x7f070035
+			public const int fill_vertical = 2131165237;
 			
-			// aapt resource value: 0x7f06003b
-			public const int @fixed = 2131099707;
+			// aapt resource value: 0x7f07003b
+			public const int @fixed = 2131165243;
 			
-			// aapt resource value: 0x7f060005
-			public const int home = 2131099653;
+			// aapt resource value: 0x7f070005
+			public const int home = 2131165189;
 			
-			// aapt resource value: 0x7f060011
-			public const int homeAsUp = 2131099665;
+			// aapt resource value: 0x7f070011
+			public const int homeAsUp = 2131165201;
 			
-			// aapt resource value: 0x7f060045
-			public const int icon = 2131099717;
+			// aapt resource value: 0x7f070045
+			public const int icon = 2131165253;
 			
-			// aapt resource value: 0x7f06001c
-			public const int ifRoom = 2131099676;
+			// aapt resource value: 0x7f07001c
+			public const int ifRoom = 2131165212;
 			
-			// aapt resource value: 0x7f060042
-			public const int image = 2131099714;
+			// aapt resource value: 0x7f070042
+			public const int image = 2131165250;
 			
-			// aapt resource value: 0x7f060083
-			public const int info = 2131099779;
+			// aapt resource value: 0x7f070083
+			public const int info = 2131165315;
 			
-			// aapt resource value: 0x7f060077
-			public const int innerText = 2131099767;
+			// aapt resource value: 0x7f070077
+			public const int innerText = 2131165303;
 			
-			// aapt resource value: 0x7f060000
-			public const int item_touch_helper_previous_elevation = 2131099648;
+			// aapt resource value: 0x7f070000
+			public const int item_touch_helper_previous_elevation = 2131165184;
 			
-			// aapt resource value: 0x7f060036
-			public const int left = 2131099702;
+			// aapt resource value: 0x7f070036
+			public const int left = 2131165238;
 			
-			// aapt resource value: 0x7f06007d
-			public const int line1 = 2131099773;
+			// aapt resource value: 0x7f07007d
+			public const int line1 = 2131165309;
 			
-			// aapt resource value: 0x7f060081
-			public const int line3 = 2131099777;
+			// aapt resource value: 0x7f070081
+			public const int line3 = 2131165313;
 			
-			// aapt resource value: 0x7f06000d
-			public const int listMode = 2131099661;
+			// aapt resource value: 0x7f07000d
+			public const int listMode = 2131165197;
 			
-			// aapt resource value: 0x7f060044
-			public const int list_item = 2131099716;
+			// aapt resource value: 0x7f070044
+			public const int list_item = 2131165252;
 			
-			// aapt resource value: 0x7f06006c
-			public const int main_content = 2131099756;
+			// aapt resource value: 0x7f07006c
+			public const int main_content = 2131165292;
 			
-			// aapt resource value: 0x7f06007b
-			public const int media_actions = 2131099771;
+			// aapt resource value: 0x7f07007b
+			public const int media_actions = 2131165307;
 			
-			// aapt resource value: 0x7f060019
-			public const int middle = 2131099673;
+			// aapt resource value: 0x7f070019
+			public const int middle = 2131165209;
 			
-			// aapt resource value: 0x7f06003a
-			public const int mini = 2131099706;
+			// aapt resource value: 0x7f07003a
+			public const int mini = 2131165242;
 			
-			// aapt resource value: 0x7f060022
-			public const int multiply = 2131099682;
+			// aapt resource value: 0x7f070022
+			public const int multiply = 2131165218;
 			
-			// aapt resource value: 0x7f060073
-			public const int my_recycler_view = 2131099763;
+			// aapt resource value: 0x7f070073
+			public const int my_recycler_view = 2131165299;
 			
-			// aapt resource value: 0x7f060087
-			public const int nav_footer = 2131099783;
+			// aapt resource value: 0x7f070087
+			public const int nav_footer = 2131165319;
 			
-			// aapt resource value: 0x7f060089
-			public const int nav_helpfeedback = 2131099785;
+			// aapt resource value: 0x7f070089
+			public const int nav_helpfeedback = 2131165321;
 			
-			// aapt resource value: 0x7f060086
-			public const int nav_home = 2131099782;
+			// aapt resource value: 0x7f070086
+			public const int nav_home = 2131165318;
 			
-			// aapt resource value: 0x7f060085
-			public const int nav_items = 2131099781;
+			// aapt resource value: 0x7f070085
+			public const int nav_items = 2131165317;
 			
-			// aapt resource value: 0x7f060088
-			public const int nav_settings = 2131099784;
+			// aapt resource value: 0x7f070088
+			public const int nav_settings = 2131165320;
 			
-			// aapt resource value: 0x7f06006b
-			public const int navigation_frame = 2131099755;
+			// aapt resource value: 0x7f07006b
+			public const int navigation_frame = 2131165291;
 			
-			// aapt resource value: 0x7f060071
-			public const int navigation_view = 2131099761;
+			// aapt resource value: 0x7f070071
+			public const int navigation_view = 2131165297;
 			
-			// aapt resource value: 0x7f06001d
-			public const int never = 2131099677;
+			// aapt resource value: 0x7f07001d
+			public const int never = 2131165213;
 			
-			// aapt resource value: 0x7f060012
-			public const int none = 2131099666;
+			// aapt resource value: 0x7f070012
+			public const int none = 2131165202;
 			
-			// aapt resource value: 0x7f06000e
-			public const int normal = 2131099662;
+			// aapt resource value: 0x7f07000e
+			public const int normal = 2131165198;
 			
-			// aapt resource value: 0x7f06002b
-			public const int parallax = 2131099691;
+			// aapt resource value: 0x7f07002b
+			public const int parallax = 2131165227;
 			
-			// aapt resource value: 0x7f060047
-			public const int parentPanel = 2131099719;
+			// aapt resource value: 0x7f070047
+			public const int parentPanel = 2131165255;
 			
-			// aapt resource value: 0x7f06002c
-			public const int pin = 2131099692;
+			// aapt resource value: 0x7f07002c
+			public const int pin = 2131165228;
 			
-			// aapt resource value: 0x7f060006
-			public const int progress_circular = 2131099654;
+			// aapt resource value: 0x7f070006
+			public const int progress_circular = 2131165190;
 			
-			// aapt resource value: 0x7f060007
-			public const int progress_horizontal = 2131099655;
+			// aapt resource value: 0x7f070007
+			public const int progress_horizontal = 2131165191;
 			
-			// aapt resource value: 0x7f060054
-			public const int radio = 2131099732;
+			// aapt resource value: 0x7f070054
+			public const int radio = 2131165268;
 			
-			// aapt resource value: 0x7f060072
-			public const int refresher = 2131099762;
+			// aapt resource value: 0x7f070072
+			public const int refresher = 2131165298;
 			
-			// aapt resource value: 0x7f060037
-			public const int right = 2131099703;
+			// aapt resource value: 0x7f070037
+			public const int right = 2131165239;
 			
-			// aapt resource value: 0x7f060023
-			public const int screen = 2131099683;
+			// aapt resource value: 0x7f070023
+			public const int screen = 2131165219;
 			
-			// aapt resource value: 0x7f06002a
-			public const int scroll = 2131099690;
+			// aapt resource value: 0x7f07002a
+			public const int scroll = 2131165226;
 			
-			// aapt resource value: 0x7f06004c
-			public const int scrollView = 2131099724;
+			// aapt resource value: 0x7f07004c
+			public const int scrollView = 2131165260;
 			
-			// aapt resource value: 0x7f06003c
-			public const int scrollable = 2131099708;
+			// aapt resource value: 0x7f07003c
+			public const int scrollable = 2131165244;
 			
-			// aapt resource value: 0x7f06005e
-			public const int search_badge = 2131099742;
+			// aapt resource value: 0x7f07005e
+			public const int search_badge = 2131165278;
 			
-			// aapt resource value: 0x7f06005d
-			public const int search_bar = 2131099741;
+			// aapt resource value: 0x7f07005d
+			public const int search_bar = 2131165277;
 			
-			// aapt resource value: 0x7f06005f
-			public const int search_button = 2131099743;
+			// aapt resource value: 0x7f07005f
+			public const int search_button = 2131165279;
 			
-			// aapt resource value: 0x7f060064
-			public const int search_close_btn = 2131099748;
+			// aapt resource value: 0x7f070064
+			public const int search_close_btn = 2131165284;
 			
-			// aapt resource value: 0x7f060060
-			public const int search_edit_frame = 2131099744;
+			// aapt resource value: 0x7f070060
+			public const int search_edit_frame = 2131165280;
 			
-			// aapt resource value: 0x7f060066
-			public const int search_go_btn = 2131099750;
+			// aapt resource value: 0x7f070066
+			public const int search_go_btn = 2131165286;
 			
-			// aapt resource value: 0x7f060061
-			public const int search_mag_icon = 2131099745;
+			// aapt resource value: 0x7f070061
+			public const int search_mag_icon = 2131165281;
 			
-			// aapt resource value: 0x7f060062
-			public const int search_plate = 2131099746;
+			// aapt resource value: 0x7f070062
+			public const int search_plate = 2131165282;
 			
-			// aapt resource value: 0x7f060063
-			public const int search_src_text = 2131099747;
+			// aapt resource value: 0x7f070063
+			public const int search_src_text = 2131165283;
 			
-			// aapt resource value: 0x7f060067
-			public const int search_voice_btn = 2131099751;
+			// aapt resource value: 0x7f070067
+			public const int search_voice_btn = 2131165287;
 			
-			// aapt resource value: 0x7f060068
-			public const int select_dialog_listview = 2131099752;
+			// aapt resource value: 0x7f070068
+			public const int select_dialog_listview = 2131165288;
 			
-			// aapt resource value: 0x7f060053
-			public const int shortcut = 2131099731;
+			// aapt resource value: 0x7f070053
+			public const int shortcut = 2131165267;
 			
-			// aapt resource value: 0x7f060013
-			public const int showCustom = 2131099667;
+			// aapt resource value: 0x7f070013
+			public const int showCustom = 2131165203;
 			
-			// aapt resource value: 0x7f060014
-			public const int showHome = 2131099668;
+			// aapt resource value: 0x7f070014
+			public const int showHome = 2131165204;
 			
-			// aapt resource value: 0x7f060015
-			public const int showTitle = 2131099669;
+			// aapt resource value: 0x7f070015
+			public const int showTitle = 2131165205;
 			
-			// aapt resource value: 0x7f060076
-			public const int snackbar_action = 2131099766;
+			// aapt resource value: 0x7f070076
+			public const int snackbar_action = 2131165302;
 			
-			// aapt resource value: 0x7f060075
-			public const int snackbar_text = 2131099765;
+			// aapt resource value: 0x7f070075
+			public const int snackbar_text = 2131165301;
 			
-			// aapt resource value: 0x7f060008
-			public const int split_action_bar = 2131099656;
+			// aapt resource value: 0x7f070008
+			public const int split_action_bar = 2131165192;
 			
-			// aapt resource value: 0x7f060024
-			public const int src_atop = 2131099684;
+			// aapt resource value: 0x7f070024
+			public const int src_atop = 2131165220;
 			
-			// aapt resource value: 0x7f060025
-			public const int src_in = 2131099685;
+			// aapt resource value: 0x7f070025
+			public const int src_in = 2131165221;
 			
-			// aapt resource value: 0x7f060026
-			public const int src_over = 2131099686;
+			// aapt resource value: 0x7f070026
+			public const int src_over = 2131165222;
 			
-			// aapt resource value: 0x7f060038
-			public const int start = 2131099704;
+			// aapt resource value: 0x7f070038
+			public const int start = 2131165240;
 			
-			// aapt resource value: 0x7f06007a
-			public const int status_bar_latest_event_content = 2131099770;
+			// aapt resource value: 0x7f07007a
+			public const int status_bar_latest_event_content = 2131165306;
 			
-			// aapt resource value: 0x7f060065
-			public const int submit_area = 2131099749;
+			// aapt resource value: 0x7f070065
+			public const int submit_area = 2131165285;
 			
-			// aapt resource value: 0x7f06000f
-			public const int tabMode = 2131099663;
+			// aapt resource value: 0x7f07000f
+			public const int tabMode = 2131165199;
 			
-			// aapt resource value: 0x7f06006f
-			public const int tabs = 2131099759;
+			// aapt resource value: 0x7f07006f
+			public const int tabs = 2131165295;
 			
-			// aapt resource value: 0x7f060082
-			public const int text = 2131099778;
+			// aapt resource value: 0x7f070082
+			public const int text = 2131165314;
 			
-			// aapt resource value: 0x7f060080
-			public const int text2 = 2131099776;
+			// aapt resource value: 0x7f070080
+			public const int text2 = 2131165312;
 			
-			// aapt resource value: 0x7f06004d
-			public const int textSpacerNoButtons = 2131099725;
+			// aapt resource value: 0x7f07004d
+			public const int textSpacerNoButtons = 2131165261;
 			
-			// aapt resource value: 0x7f060074
-			public const int textView1 = 2131099764;
+			// aapt resource value: 0x7f070074
+			public const int textView1 = 2131165300;
 			
-			// aapt resource value: 0x7f06007e
-			public const int time = 2131099774;
+			// aapt resource value: 0x7f07007e
+			public const int time = 2131165310;
 			
-			// aapt resource value: 0x7f060046
-			public const int title = 2131099718;
+			// aapt resource value: 0x7f070046
+			public const int title = 2131165254;
 			
-			// aapt resource value: 0x7f060049
-			public const int title_template = 2131099721;
+			// aapt resource value: 0x7f070049
+			public const int title_template = 2131165257;
 			
-			// aapt resource value: 0x7f06006e
-			public const int toolbar = 2131099758;
+			// aapt resource value: 0x7f07006e
+			public const int toolbar = 2131165294;
 			
-			// aapt resource value: 0x7f060039
-			public const int top = 2131099705;
+			// aapt resource value: 0x7f070039
+			public const int top = 2131165241;
 			
-			// aapt resource value: 0x7f060048
-			public const int topPanel = 2131099720;
+			// aapt resource value: 0x7f070048
+			public const int topPanel = 2131165256;
 			
-			// aapt resource value: 0x7f060009
-			public const int up = 2131099657;
+			// aapt resource value: 0x7f070009
+			public const int up = 2131165193;
 			
-			// aapt resource value: 0x7f060016
-			public const int useLogo = 2131099670;
+			// aapt resource value: 0x7f070016
+			public const int useLogo = 2131165206;
 			
-			// aapt resource value: 0x7f06000a
-			public const int view_offset_helper = 2131099658;
+			// aapt resource value: 0x7f07000a
+			public const int view_offset_helper = 2131165194;
 			
-			// aapt resource value: 0x7f060070
-			public const int viewpager = 2131099760;
+			// aapt resource value: 0x7f070070
+			public const int viewpager = 2131165296;
 			
-			// aapt resource value: 0x7f06001e
-			public const int withText = 2131099678;
+			// aapt resource value: 0x7f07001e
+			public const int withText = 2131165214;
 			
-			// aapt resource value: 0x7f060021
-			public const int wrap_content = 2131099681;
+			// aapt resource value: 0x7f070021
+			public const int wrap_content = 2131165217;
 			
 			static Id()
 			{
@@ -2117,23 +2120,23 @@ namespace Example.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f0a0001
-			public const int abc_config_activityDefaultDur = 2131361793;
+			// aapt resource value: 0x7f0b0001
+			public const int abc_config_activityDefaultDur = 2131427329;
 			
-			// aapt resource value: 0x7f0a0002
-			public const int abc_config_activityShortDur = 2131361794;
+			// aapt resource value: 0x7f0b0002
+			public const int abc_config_activityShortDur = 2131427330;
 			
-			// aapt resource value: 0x7f0a0000
-			public const int abc_max_action_buttons = 2131361792;
+			// aapt resource value: 0x7f0b0000
+			public const int abc_max_action_buttons = 2131427328;
 			
-			// aapt resource value: 0x7f0a0003
-			public const int cancel_button_image_alpha = 2131361795;
+			// aapt resource value: 0x7f0b0003
+			public const int cancel_button_image_alpha = 2131427331;
 			
-			// aapt resource value: 0x7f0a0005
-			public const int snackbar_text_max_lines = 2131361797;
+			// aapt resource value: 0x7f0b0005
+			public const int snackbar_text_max_lines = 2131427333;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int status_bar_notification_info_maxnum = 2131361796;
+			// aapt resource value: 0x7f0b0004
+			public const int status_bar_notification_info_maxnum = 2131427332;
 			
 			static Integer()
 			{
@@ -2323,8 +2326,8 @@ namespace Example.Droid
 		public partial class Menu
 		{
 			
-			// aapt resource value: 0x7f0c0000
-			public const int navigation_drawer = 2131492864;
+			// aapt resource value: 0x7f0d0000
+			public const int navigation_drawer = 2131558400;
 			
 			static Menu()
 			{
@@ -2339,74 +2342,74 @@ namespace Example.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f070000
-			public const int abc_action_bar_home_description = 2131165184;
+			// aapt resource value: 0x7f080000
+			public const int abc_action_bar_home_description = 2131230720;
 			
-			// aapt resource value: 0x7f07000d
-			public const int abc_action_bar_home_description_format = 2131165197;
+			// aapt resource value: 0x7f08000d
+			public const int abc_action_bar_home_description_format = 2131230733;
 			
-			// aapt resource value: 0x7f07000e
-			public const int abc_action_bar_home_subtitle_description_format = 2131165198;
+			// aapt resource value: 0x7f08000e
+			public const int abc_action_bar_home_subtitle_description_format = 2131230734;
 			
-			// aapt resource value: 0x7f070001
-			public const int abc_action_bar_up_description = 2131165185;
+			// aapt resource value: 0x7f080001
+			public const int abc_action_bar_up_description = 2131230721;
 			
-			// aapt resource value: 0x7f070002
-			public const int abc_action_menu_overflow_description = 2131165186;
+			// aapt resource value: 0x7f080002
+			public const int abc_action_menu_overflow_description = 2131230722;
 			
-			// aapt resource value: 0x7f070003
-			public const int abc_action_mode_done = 2131165187;
+			// aapt resource value: 0x7f080003
+			public const int abc_action_mode_done = 2131230723;
 			
-			// aapt resource value: 0x7f070004
-			public const int abc_activity_chooser_view_see_all = 2131165188;
+			// aapt resource value: 0x7f080004
+			public const int abc_activity_chooser_view_see_all = 2131230724;
 			
-			// aapt resource value: 0x7f070005
-			public const int abc_activitychooserview_choose_application = 2131165189;
+			// aapt resource value: 0x7f080005
+			public const int abc_activitychooserview_choose_application = 2131230725;
 			
-			// aapt resource value: 0x7f07000f
-			public const int abc_search_hint = 2131165199;
+			// aapt resource value: 0x7f08000f
+			public const int abc_search_hint = 2131230735;
 			
-			// aapt resource value: 0x7f070006
-			public const int abc_searchview_description_clear = 2131165190;
+			// aapt resource value: 0x7f080006
+			public const int abc_searchview_description_clear = 2131230726;
 			
-			// aapt resource value: 0x7f070007
-			public const int abc_searchview_description_query = 2131165191;
+			// aapt resource value: 0x7f080007
+			public const int abc_searchview_description_query = 2131230727;
 			
-			// aapt resource value: 0x7f070008
-			public const int abc_searchview_description_search = 2131165192;
+			// aapt resource value: 0x7f080008
+			public const int abc_searchview_description_search = 2131230728;
 			
-			// aapt resource value: 0x7f070009
-			public const int abc_searchview_description_submit = 2131165193;
+			// aapt resource value: 0x7f080009
+			public const int abc_searchview_description_submit = 2131230729;
 			
-			// aapt resource value: 0x7f07000a
-			public const int abc_searchview_description_voice = 2131165194;
+			// aapt resource value: 0x7f08000a
+			public const int abc_searchview_description_voice = 2131230730;
 			
-			// aapt resource value: 0x7f07000b
-			public const int abc_shareactionprovider_share_with = 2131165195;
+			// aapt resource value: 0x7f08000b
+			public const int abc_shareactionprovider_share_with = 2131230731;
 			
-			// aapt resource value: 0x7f07000c
-			public const int abc_shareactionprovider_share_with_application = 2131165196;
+			// aapt resource value: 0x7f08000c
+			public const int abc_shareactionprovider_share_with_application = 2131230732;
 			
-			// aapt resource value: 0x7f070010
-			public const int abc_toolbar_collapse_description = 2131165200;
+			// aapt resource value: 0x7f080010
+			public const int abc_toolbar_collapse_description = 2131230736;
 			
-			// aapt resource value: 0x7f070014
-			public const int app_name = 2131165204;
+			// aapt resource value: 0x7f080014
+			public const int app_name = 2131230740;
 			
-			// aapt resource value: 0x7f070012
-			public const int appbar_scrolling_view_behavior = 2131165202;
+			// aapt resource value: 0x7f080012
+			public const int appbar_scrolling_view_behavior = 2131230738;
 			
-			// aapt resource value: 0x7f070016
-			public const int drawer_close = 2131165206;
+			// aapt resource value: 0x7f080016
+			public const int drawer_close = 2131230742;
 			
-			// aapt resource value: 0x7f070015
-			public const int drawer_open = 2131165205;
+			// aapt resource value: 0x7f080015
+			public const int drawer_open = 2131230741;
 			
-			// aapt resource value: 0x7f070013
-			public const int hello = 2131165203;
+			// aapt resource value: 0x7f080013
+			public const int hello = 2131230739;
 			
-			// aapt resource value: 0x7f070011
-			public const int status_bar_notification_info_overflow = 2131165201;
+			// aapt resource value: 0x7f080011
+			public const int status_bar_notification_info_overflow = 2131230737;
 			
 			static String()
 			{
@@ -2421,938 +2424,941 @@ namespace Example.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f080073
-			public const int AlertDialog_AppCompat = 2131230835;
+			// aapt resource value: 0x7f090073
+			public const int AlertDialog_AppCompat = 2131296371;
 			
-			// aapt resource value: 0x7f080074
-			public const int AlertDialog_AppCompat_Light = 2131230836;
+			// aapt resource value: 0x7f090074
+			public const int AlertDialog_AppCompat_Light = 2131296372;
 			
-			// aapt resource value: 0x7f080075
-			public const int Animation_AppCompat_Dialog = 2131230837;
+			// aapt resource value: 0x7f090075
+			public const int Animation_AppCompat_Dialog = 2131296373;
 			
-			// aapt resource value: 0x7f080076
-			public const int Animation_AppCompat_DropDownUp = 2131230838;
+			// aapt resource value: 0x7f090076
+			public const int Animation_AppCompat_DropDownUp = 2131296374;
 			
-			// aapt resource value: 0x7f080134
-			public const int AppTheme = 2131231028;
+			// aapt resource value: 0x7f090134
+			public const int AppTheme = 2131296564;
 			
-			// aapt resource value: 0x7f080135
-			public const int AppTheme_Base = 2131231029;
+			// aapt resource value: 0x7f090135
+			public const int AppTheme_Base = 2131296565;
 			
-			// aapt resource value: 0x7f080136
-			public const int AppTheme_Splash = 2131231030;
+			// aapt resource value: 0x7f090136
+			public const int AppTheme_Splash = 2131296566;
 			
-			// aapt resource value: 0x7f080077
-			public const int Base_AlertDialog_AppCompat = 2131230839;
+			// aapt resource value: 0x7f090077
+			public const int Base_AlertDialog_AppCompat = 2131296375;
 			
-			// aapt resource value: 0x7f080078
-			public const int Base_AlertDialog_AppCompat_Light = 2131230840;
+			// aapt resource value: 0x7f090078
+			public const int Base_AlertDialog_AppCompat_Light = 2131296376;
 			
-			// aapt resource value: 0x7f080079
-			public const int Base_Animation_AppCompat_Dialog = 2131230841;
+			// aapt resource value: 0x7f090079
+			public const int Base_Animation_AppCompat_Dialog = 2131296377;
 			
-			// aapt resource value: 0x7f08007a
-			public const int Base_Animation_AppCompat_DropDownUp = 2131230842;
+			// aapt resource value: 0x7f09007a
+			public const int Base_Animation_AppCompat_DropDownUp = 2131296378;
 			
-			// aapt resource value: 0x7f08007b
-			public const int Base_DialogWindowTitle_AppCompat = 2131230843;
+			// aapt resource value: 0x7f09007b
+			public const int Base_DialogWindowTitle_AppCompat = 2131296379;
 			
-			// aapt resource value: 0x7f08007c
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131230844;
+			// aapt resource value: 0x7f09007c
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131296380;
 			
-			// aapt resource value: 0x7f08002e
-			public const int Base_TextAppearance_AppCompat = 2131230766;
+			// aapt resource value: 0x7f09002e
+			public const int Base_TextAppearance_AppCompat = 2131296302;
 			
-			// aapt resource value: 0x7f08002f
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131230767;
+			// aapt resource value: 0x7f09002f
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131296303;
 			
-			// aapt resource value: 0x7f080030
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131230768;
+			// aapt resource value: 0x7f090030
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131296304;
 			
-			// aapt resource value: 0x7f080018
-			public const int Base_TextAppearance_AppCompat_Button = 2131230744;
+			// aapt resource value: 0x7f090018
+			public const int Base_TextAppearance_AppCompat_Button = 2131296280;
 			
-			// aapt resource value: 0x7f080031
-			public const int Base_TextAppearance_AppCompat_Caption = 2131230769;
+			// aapt resource value: 0x7f090031
+			public const int Base_TextAppearance_AppCompat_Caption = 2131296305;
 			
-			// aapt resource value: 0x7f080032
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131230770;
+			// aapt resource value: 0x7f090032
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131296306;
 			
-			// aapt resource value: 0x7f080033
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131230771;
+			// aapt resource value: 0x7f090033
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131296307;
 			
-			// aapt resource value: 0x7f080034
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131230772;
+			// aapt resource value: 0x7f090034
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131296308;
 			
-			// aapt resource value: 0x7f080035
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131230773;
+			// aapt resource value: 0x7f090035
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131296309;
 			
-			// aapt resource value: 0x7f080036
-			public const int Base_TextAppearance_AppCompat_Headline = 2131230774;
+			// aapt resource value: 0x7f090036
+			public const int Base_TextAppearance_AppCompat_Headline = 2131296310;
 			
-			// aapt resource value: 0x7f080003
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131230723;
+			// aapt resource value: 0x7f090003
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131296259;
 			
-			// aapt resource value: 0x7f080037
-			public const int Base_TextAppearance_AppCompat_Large = 2131230775;
+			// aapt resource value: 0x7f090037
+			public const int Base_TextAppearance_AppCompat_Large = 2131296311;
 			
-			// aapt resource value: 0x7f080004
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131230724;
+			// aapt resource value: 0x7f090004
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131296260;
 			
-			// aapt resource value: 0x7f080038
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131230776;
+			// aapt resource value: 0x7f090038
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296312;
 			
-			// aapt resource value: 0x7f080039
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131230777;
+			// aapt resource value: 0x7f090039
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296313;
 			
-			// aapt resource value: 0x7f08003a
-			public const int Base_TextAppearance_AppCompat_Medium = 2131230778;
+			// aapt resource value: 0x7f09003a
+			public const int Base_TextAppearance_AppCompat_Medium = 2131296314;
 			
-			// aapt resource value: 0x7f080005
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131230725;
+			// aapt resource value: 0x7f090005
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296261;
 			
-			// aapt resource value: 0x7f08003b
-			public const int Base_TextAppearance_AppCompat_Menu = 2131230779;
+			// aapt resource value: 0x7f09003b
+			public const int Base_TextAppearance_AppCompat_Menu = 2131296315;
 			
-			// aapt resource value: 0x7f08007d
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131230845;
+			// aapt resource value: 0x7f09007d
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131296381;
 			
-			// aapt resource value: 0x7f08003c
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131230780;
+			// aapt resource value: 0x7f09003c
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296316;
 			
-			// aapt resource value: 0x7f08003d
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131230781;
+			// aapt resource value: 0x7f09003d
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296317;
 			
-			// aapt resource value: 0x7f08003e
-			public const int Base_TextAppearance_AppCompat_Small = 2131230782;
+			// aapt resource value: 0x7f09003e
+			public const int Base_TextAppearance_AppCompat_Small = 2131296318;
 			
-			// aapt resource value: 0x7f080006
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131230726;
+			// aapt resource value: 0x7f090006
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131296262;
 			
-			// aapt resource value: 0x7f08003f
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131230783;
+			// aapt resource value: 0x7f09003f
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131296319;
 			
-			// aapt resource value: 0x7f080007
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131230727;
+			// aapt resource value: 0x7f090007
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296263;
 			
-			// aapt resource value: 0x7f080040
-			public const int Base_TextAppearance_AppCompat_Title = 2131230784;
+			// aapt resource value: 0x7f090040
+			public const int Base_TextAppearance_AppCompat_Title = 2131296320;
 			
-			// aapt resource value: 0x7f080008
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131230728;
+			// aapt resource value: 0x7f090008
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131296264;
 			
-			// aapt resource value: 0x7f080041
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131230785;
+			// aapt resource value: 0x7f090041
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296321;
 			
-			// aapt resource value: 0x7f080042
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131230786;
+			// aapt resource value: 0x7f090042
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296322;
 			
-			// aapt resource value: 0x7f080043
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131230787;
+			// aapt resource value: 0x7f090043
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296323;
 			
-			// aapt resource value: 0x7f080044
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131230788;
+			// aapt resource value: 0x7f090044
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296324;
 			
-			// aapt resource value: 0x7f080045
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131230789;
+			// aapt resource value: 0x7f090045
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296325;
 			
-			// aapt resource value: 0x7f080046
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131230790;
+			// aapt resource value: 0x7f090046
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296326;
 			
-			// aapt resource value: 0x7f080047
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131230791;
+			// aapt resource value: 0x7f090047
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296327;
 			
-			// aapt resource value: 0x7f08007e
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131230846;
+			// aapt resource value: 0x7f09007e
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296382;
 			
-			// aapt resource value: 0x7f080048
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131230792;
+			// aapt resource value: 0x7f090048
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296328;
 			
-			// aapt resource value: 0x7f080049
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131230793;
+			// aapt resource value: 0x7f090049
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296329;
 			
-			// aapt resource value: 0x7f08004a
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131230794;
+			// aapt resource value: 0x7f09004a
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131296330;
 			
-			// aapt resource value: 0x7f08004b
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131230795;
+			// aapt resource value: 0x7f09004b
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296331;
 			
-			// aapt resource value: 0x7f08007f
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131230847;
+			// aapt resource value: 0x7f09007f
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296383;
 			
-			// aapt resource value: 0x7f08004c
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131230796;
+			// aapt resource value: 0x7f09004c
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296332;
 			
-			// aapt resource value: 0x7f08004d
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131230797;
+			// aapt resource value: 0x7f09004d
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296333;
 			
-			// aapt resource value: 0x7f08004e
-			public const int Base_Theme_AppCompat = 2131230798;
+			// aapt resource value: 0x7f09004e
+			public const int Base_Theme_AppCompat = 2131296334;
 			
-			// aapt resource value: 0x7f080080
-			public const int Base_Theme_AppCompat_CompactMenu = 2131230848;
+			// aapt resource value: 0x7f090080
+			public const int Base_Theme_AppCompat_CompactMenu = 2131296384;
 			
-			// aapt resource value: 0x7f080009
-			public const int Base_Theme_AppCompat_Dialog = 2131230729;
+			// aapt resource value: 0x7f090009
+			public const int Base_Theme_AppCompat_Dialog = 2131296265;
 			
-			// aapt resource value: 0x7f080081
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131230849;
+			// aapt resource value: 0x7f090081
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131296385;
 			
-			// aapt resource value: 0x7f080082
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131230850;
+			// aapt resource value: 0x7f090082
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131296386;
 			
-			// aapt resource value: 0x7f080083
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131230851;
+			// aapt resource value: 0x7f090083
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131296387;
 			
-			// aapt resource value: 0x7f080001
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131230721;
+			// aapt resource value: 0x7f090001
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131296257;
 			
-			// aapt resource value: 0x7f08004f
-			public const int Base_Theme_AppCompat_Light = 2131230799;
+			// aapt resource value: 0x7f09004f
+			public const int Base_Theme_AppCompat_Light = 2131296335;
 			
-			// aapt resource value: 0x7f080084
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131230852;
+			// aapt resource value: 0x7f090084
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131296388;
 			
-			// aapt resource value: 0x7f08000a
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131230730;
+			// aapt resource value: 0x7f09000a
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131296266;
 			
-			// aapt resource value: 0x7f080085
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131230853;
+			// aapt resource value: 0x7f090085
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296389;
 			
-			// aapt resource value: 0x7f080086
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131230854;
+			// aapt resource value: 0x7f090086
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296390;
 			
-			// aapt resource value: 0x7f080087
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131230855;
+			// aapt resource value: 0x7f090087
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296391;
 			
-			// aapt resource value: 0x7f080002
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131230722;
+			// aapt resource value: 0x7f090002
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296258;
 			
-			// aapt resource value: 0x7f080088
-			public const int Base_ThemeOverlay_AppCompat = 2131230856;
+			// aapt resource value: 0x7f090088
+			public const int Base_ThemeOverlay_AppCompat = 2131296392;
 			
-			// aapt resource value: 0x7f080089
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131230857;
+			// aapt resource value: 0x7f090089
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131296393;
 			
-			// aapt resource value: 0x7f08008a
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131230858;
+			// aapt resource value: 0x7f09008a
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131296394;
 			
-			// aapt resource value: 0x7f08008b
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131230859;
+			// aapt resource value: 0x7f09008b
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296395;
 			
-			// aapt resource value: 0x7f08008c
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131230860;
+			// aapt resource value: 0x7f09008c
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131296396;
 			
-			// aapt resource value: 0x7f08000b
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131230731;
+			// aapt resource value: 0x7f09000b
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131296267;
 			
-			// aapt resource value: 0x7f08000c
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131230732;
+			// aapt resource value: 0x7f09000c
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131296268;
 			
-			// aapt resource value: 0x7f080014
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131230740;
+			// aapt resource value: 0x7f090014
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296276;
 			
-			// aapt resource value: 0x7f080015
-			public const int Base_V12_Widget_AppCompat_EditText = 2131230741;
+			// aapt resource value: 0x7f090015
+			public const int Base_V12_Widget_AppCompat_EditText = 2131296277;
 			
-			// aapt resource value: 0x7f080050
-			public const int Base_V21_Theme_AppCompat = 2131230800;
+			// aapt resource value: 0x7f090050
+			public const int Base_V21_Theme_AppCompat = 2131296336;
 			
-			// aapt resource value: 0x7f080051
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131230801;
+			// aapt resource value: 0x7f090051
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131296337;
 			
-			// aapt resource value: 0x7f080052
-			public const int Base_V21_Theme_AppCompat_Light = 2131230802;
+			// aapt resource value: 0x7f090052
+			public const int Base_V21_Theme_AppCompat_Light = 2131296338;
 			
-			// aapt resource value: 0x7f080053
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131230803;
+			// aapt resource value: 0x7f090053
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131296339;
 			
-			// aapt resource value: 0x7f08008d
-			public const int Base_V7_Theme_AppCompat = 2131230861;
+			// aapt resource value: 0x7f09008d
+			public const int Base_V7_Theme_AppCompat = 2131296397;
 			
-			// aapt resource value: 0x7f08008e
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131230862;
+			// aapt resource value: 0x7f09008e
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131296398;
 			
-			// aapt resource value: 0x7f08008f
-			public const int Base_V7_Theme_AppCompat_Light = 2131230863;
+			// aapt resource value: 0x7f09008f
+			public const int Base_V7_Theme_AppCompat_Light = 2131296399;
 			
-			// aapt resource value: 0x7f080090
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131230864;
+			// aapt resource value: 0x7f090090
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131296400;
 			
-			// aapt resource value: 0x7f080091
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131230865;
+			// aapt resource value: 0x7f090091
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296401;
 			
-			// aapt resource value: 0x7f080092
-			public const int Base_V7_Widget_AppCompat_EditText = 2131230866;
+			// aapt resource value: 0x7f090092
+			public const int Base_V7_Widget_AppCompat_EditText = 2131296402;
 			
-			// aapt resource value: 0x7f080093
-			public const int Base_Widget_AppCompat_ActionBar = 2131230867;
+			// aapt resource value: 0x7f090093
+			public const int Base_Widget_AppCompat_ActionBar = 2131296403;
 			
-			// aapt resource value: 0x7f080094
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131230868;
+			// aapt resource value: 0x7f090094
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131296404;
 			
-			// aapt resource value: 0x7f080095
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131230869;
+			// aapt resource value: 0x7f090095
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131296405;
 			
-			// aapt resource value: 0x7f080054
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131230804;
+			// aapt resource value: 0x7f090054
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131296340;
 			
-			// aapt resource value: 0x7f080055
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131230805;
+			// aapt resource value: 0x7f090055
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131296341;
 			
-			// aapt resource value: 0x7f080056
-			public const int Base_Widget_AppCompat_ActionButton = 2131230806;
+			// aapt resource value: 0x7f090056
+			public const int Base_Widget_AppCompat_ActionButton = 2131296342;
 			
-			// aapt resource value: 0x7f080057
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131230807;
+			// aapt resource value: 0x7f090057
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296343;
 			
-			// aapt resource value: 0x7f080058
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131230808;
+			// aapt resource value: 0x7f090058
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131296344;
 			
-			// aapt resource value: 0x7f080096
-			public const int Base_Widget_AppCompat_ActionMode = 2131230870;
+			// aapt resource value: 0x7f090096
+			public const int Base_Widget_AppCompat_ActionMode = 2131296406;
 			
-			// aapt resource value: 0x7f080097
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131230871;
+			// aapt resource value: 0x7f090097
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131296407;
 			
-			// aapt resource value: 0x7f080016
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131230742;
+			// aapt resource value: 0x7f090016
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131296278;
 			
-			// aapt resource value: 0x7f080059
-			public const int Base_Widget_AppCompat_Button = 2131230809;
+			// aapt resource value: 0x7f090059
+			public const int Base_Widget_AppCompat_Button = 2131296345;
 			
-			// aapt resource value: 0x7f08005a
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131230810;
+			// aapt resource value: 0x7f09005a
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131296346;
 			
-			// aapt resource value: 0x7f08005b
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131230811;
+			// aapt resource value: 0x7f09005b
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296347;
 			
-			// aapt resource value: 0x7f080098
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131230872;
+			// aapt resource value: 0x7f090098
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296408;
 			
-			// aapt resource value: 0x7f08005c
-			public const int Base_Widget_AppCompat_Button_Small = 2131230812;
+			// aapt resource value: 0x7f09005c
+			public const int Base_Widget_AppCompat_Button_Small = 2131296348;
 			
-			// aapt resource value: 0x7f08005d
-			public const int Base_Widget_AppCompat_ButtonBar = 2131230813;
+			// aapt resource value: 0x7f09005d
+			public const int Base_Widget_AppCompat_ButtonBar = 2131296349;
 			
-			// aapt resource value: 0x7f080099
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131230873;
+			// aapt resource value: 0x7f090099
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296409;
 			
-			// aapt resource value: 0x7f08005e
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131230814;
+			// aapt resource value: 0x7f09005e
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296350;
 			
-			// aapt resource value: 0x7f08005f
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131230815;
+			// aapt resource value: 0x7f09005f
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296351;
 			
-			// aapt resource value: 0x7f08009a
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131230874;
+			// aapt resource value: 0x7f09009a
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131296410;
 			
-			// aapt resource value: 0x7f080000
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131230720;
+			// aapt resource value: 0x7f090000
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131296256;
 			
-			// aapt resource value: 0x7f08009b
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131230875;
+			// aapt resource value: 0x7f09009b
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296411;
 			
-			// aapt resource value: 0x7f080060
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131230816;
+			// aapt resource value: 0x7f090060
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296352;
 			
-			// aapt resource value: 0x7f080017
-			public const int Base_Widget_AppCompat_EditText = 2131230743;
+			// aapt resource value: 0x7f090017
+			public const int Base_Widget_AppCompat_EditText = 2131296279;
 			
-			// aapt resource value: 0x7f08009c
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131230876;
+			// aapt resource value: 0x7f09009c
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131296412;
 			
-			// aapt resource value: 0x7f08009d
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131230877;
+			// aapt resource value: 0x7f09009d
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296413;
 			
-			// aapt resource value: 0x7f08009e
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131230878;
+			// aapt resource value: 0x7f09009e
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296414;
 			
-			// aapt resource value: 0x7f080061
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131230817;
+			// aapt resource value: 0x7f090061
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296353;
 			
-			// aapt resource value: 0x7f080062
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131230818;
+			// aapt resource value: 0x7f090062
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296354;
 			
-			// aapt resource value: 0x7f080063
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131230819;
+			// aapt resource value: 0x7f090063
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296355;
 			
-			// aapt resource value: 0x7f080064
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131230820;
+			// aapt resource value: 0x7f090064
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131296356;
 			
-			// aapt resource value: 0x7f080065
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131230821;
+			// aapt resource value: 0x7f090065
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296357;
 			
-			// aapt resource value: 0x7f080066
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131230822;
+			// aapt resource value: 0x7f090066
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131296358;
 			
-			// aapt resource value: 0x7f080067
-			public const int Base_Widget_AppCompat_ListView = 2131230823;
+			// aapt resource value: 0x7f090067
+			public const int Base_Widget_AppCompat_ListView = 2131296359;
 			
-			// aapt resource value: 0x7f080068
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131230824;
+			// aapt resource value: 0x7f090068
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131296360;
 			
-			// aapt resource value: 0x7f080069
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131230825;
+			// aapt resource value: 0x7f090069
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131296361;
 			
-			// aapt resource value: 0x7f08006a
-			public const int Base_Widget_AppCompat_PopupMenu = 2131230826;
+			// aapt resource value: 0x7f09006a
+			public const int Base_Widget_AppCompat_PopupMenu = 2131296362;
 			
-			// aapt resource value: 0x7f08006b
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131230827;
+			// aapt resource value: 0x7f09006b
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296363;
 			
-			// aapt resource value: 0x7f08009f
-			public const int Base_Widget_AppCompat_PopupWindow = 2131230879;
+			// aapt resource value: 0x7f09009f
+			public const int Base_Widget_AppCompat_PopupWindow = 2131296415;
 			
-			// aapt resource value: 0x7f08000d
-			public const int Base_Widget_AppCompat_ProgressBar = 2131230733;
+			// aapt resource value: 0x7f09000d
+			public const int Base_Widget_AppCompat_ProgressBar = 2131296269;
 			
-			// aapt resource value: 0x7f08000e
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131230734;
+			// aapt resource value: 0x7f09000e
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296270;
 			
-			// aapt resource value: 0x7f08006c
-			public const int Base_Widget_AppCompat_RatingBar = 2131230828;
+			// aapt resource value: 0x7f09006c
+			public const int Base_Widget_AppCompat_RatingBar = 2131296364;
 			
-			// aapt resource value: 0x7f0800a0
-			public const int Base_Widget_AppCompat_SearchView = 2131230880;
+			// aapt resource value: 0x7f0900a0
+			public const int Base_Widget_AppCompat_SearchView = 2131296416;
 			
-			// aapt resource value: 0x7f0800a1
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131230881;
+			// aapt resource value: 0x7f0900a1
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131296417;
 			
-			// aapt resource value: 0x7f08000f
-			public const int Base_Widget_AppCompat_Spinner = 2131230735;
+			// aapt resource value: 0x7f09000f
+			public const int Base_Widget_AppCompat_Spinner = 2131296271;
 			
-			// aapt resource value: 0x7f08006d
-			public const int Base_Widget_AppCompat_Spinner_DropDown_ActionBar = 2131230829;
+			// aapt resource value: 0x7f09006d
+			public const int Base_Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296365;
 			
-			// aapt resource value: 0x7f08006e
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131230830;
+			// aapt resource value: 0x7f09006e
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131296366;
 			
-			// aapt resource value: 0x7f08006f
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131230831;
+			// aapt resource value: 0x7f09006f
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296367;
 			
-			// aapt resource value: 0x7f0800a2
-			public const int Base_Widget_AppCompat_Toolbar = 2131230882;
+			// aapt resource value: 0x7f0900a2
+			public const int Base_Widget_AppCompat_Toolbar = 2131296418;
 			
-			// aapt resource value: 0x7f080070
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131230832;
+			// aapt resource value: 0x7f090070
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296368;
 			
-			// aapt resource value: 0x7f080125
-			public const int Base_Widget_Design_TabLayout = 2131231013;
+			// aapt resource value: 0x7f090125
+			public const int Base_Widget_Design_TabLayout = 2131296549;
 			
-			// aapt resource value: 0x7f080010
-			public const int Platform_AppCompat = 2131230736;
+			// aapt resource value: 0x7f090137
+			public const int Mono_Android_Theme_Splash = 2131296567;
 			
-			// aapt resource value: 0x7f080011
-			public const int Platform_AppCompat_Light = 2131230737;
+			// aapt resource value: 0x7f090010
+			public const int Platform_AppCompat = 2131296272;
 			
-			// aapt resource value: 0x7f080071
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131230833;
+			// aapt resource value: 0x7f090011
+			public const int Platform_AppCompat_Light = 2131296273;
 			
-			// aapt resource value: 0x7f080072
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131230834;
+			// aapt resource value: 0x7f090071
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131296369;
 			
-			// aapt resource value: 0x7f080012
-			public const int Platform_V11_AppCompat = 2131230738;
+			// aapt resource value: 0x7f090072
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131296370;
 			
-			// aapt resource value: 0x7f080013
-			public const int Platform_V11_AppCompat_Light = 2131230739;
+			// aapt resource value: 0x7f090012
+			public const int Platform_V11_AppCompat = 2131296274;
 			
-			// aapt resource value: 0x7f080019
-			public const int Platform_V14_AppCompat = 2131230745;
+			// aapt resource value: 0x7f090013
+			public const int Platform_V11_AppCompat_Light = 2131296275;
 			
-			// aapt resource value: 0x7f08001a
-			public const int Platform_V14_AppCompat_Light = 2131230746;
+			// aapt resource value: 0x7f090019
+			public const int Platform_V14_AppCompat = 2131296281;
 			
-			// aapt resource value: 0x7f080020
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131230752;
+			// aapt resource value: 0x7f09001a
+			public const int Platform_V14_AppCompat_Light = 2131296282;
 			
-			// aapt resource value: 0x7f080021
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131230753;
+			// aapt resource value: 0x7f090020
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131296288;
 			
-			// aapt resource value: 0x7f080022
-			public const int RtlOverlay_Widget_AppCompat_ActionButton_Overflow = 2131230754;
+			// aapt resource value: 0x7f090021
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296289;
 			
-			// aapt resource value: 0x7f080023
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131230755;
+			// aapt resource value: 0x7f090022
+			public const int RtlOverlay_Widget_AppCompat_ActionButton_Overflow = 2131296290;
 			
-			// aapt resource value: 0x7f080024
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131230756;
+			// aapt resource value: 0x7f090023
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296291;
 			
-			// aapt resource value: 0x7f080025
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131230757;
+			// aapt resource value: 0x7f090024
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296292;
 			
-			// aapt resource value: 0x7f080026
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131230758;
+			// aapt resource value: 0x7f090025
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296293;
 			
-			// aapt resource value: 0x7f080027
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131230759;
+			// aapt resource value: 0x7f090026
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296294;
 			
-			// aapt resource value: 0x7f080028
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131230760;
+			// aapt resource value: 0x7f090027
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296295;
 			
-			// aapt resource value: 0x7f080029
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131230761;
+			// aapt resource value: 0x7f090028
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296296;
 			
-			// aapt resource value: 0x7f08002a
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131230762;
+			// aapt resource value: 0x7f090029
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296297;
 			
-			// aapt resource value: 0x7f08002b
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131230763;
+			// aapt resource value: 0x7f09002a
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296298;
 			
-			// aapt resource value: 0x7f08002c
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131230764;
+			// aapt resource value: 0x7f09002b
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296299;
 			
-			// aapt resource value: 0x7f08002d
-			public const int RtlOverlay_Widget_AppCompat_Toolbar_Button_Navigation = 2131230765;
+			// aapt resource value: 0x7f09002c
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296300;
 			
-			// aapt resource value: 0x7f0800a3
-			public const int TextAppearance_AppCompat = 2131230883;
+			// aapt resource value: 0x7f09002d
+			public const int RtlOverlay_Widget_AppCompat_Toolbar_Button_Navigation = 2131296301;
 			
-			// aapt resource value: 0x7f0800a4
-			public const int TextAppearance_AppCompat_Body1 = 2131230884;
+			// aapt resource value: 0x7f0900a3
+			public const int TextAppearance_AppCompat = 2131296419;
 			
-			// aapt resource value: 0x7f0800a5
-			public const int TextAppearance_AppCompat_Body2 = 2131230885;
+			// aapt resource value: 0x7f0900a4
+			public const int TextAppearance_AppCompat_Body1 = 2131296420;
 			
-			// aapt resource value: 0x7f0800a6
-			public const int TextAppearance_AppCompat_Button = 2131230886;
+			// aapt resource value: 0x7f0900a5
+			public const int TextAppearance_AppCompat_Body2 = 2131296421;
 			
-			// aapt resource value: 0x7f0800a7
-			public const int TextAppearance_AppCompat_Caption = 2131230887;
+			// aapt resource value: 0x7f0900a6
+			public const int TextAppearance_AppCompat_Button = 2131296422;
 			
-			// aapt resource value: 0x7f0800a8
-			public const int TextAppearance_AppCompat_Display1 = 2131230888;
+			// aapt resource value: 0x7f0900a7
+			public const int TextAppearance_AppCompat_Caption = 2131296423;
 			
-			// aapt resource value: 0x7f0800a9
-			public const int TextAppearance_AppCompat_Display2 = 2131230889;
+			// aapt resource value: 0x7f0900a8
+			public const int TextAppearance_AppCompat_Display1 = 2131296424;
 			
-			// aapt resource value: 0x7f0800aa
-			public const int TextAppearance_AppCompat_Display3 = 2131230890;
+			// aapt resource value: 0x7f0900a9
+			public const int TextAppearance_AppCompat_Display2 = 2131296425;
 			
-			// aapt resource value: 0x7f0800ab
-			public const int TextAppearance_AppCompat_Display4 = 2131230891;
+			// aapt resource value: 0x7f0900aa
+			public const int TextAppearance_AppCompat_Display3 = 2131296426;
 			
-			// aapt resource value: 0x7f0800ac
-			public const int TextAppearance_AppCompat_Headline = 2131230892;
+			// aapt resource value: 0x7f0900ab
+			public const int TextAppearance_AppCompat_Display4 = 2131296427;
 			
-			// aapt resource value: 0x7f0800ad
-			public const int TextAppearance_AppCompat_Inverse = 2131230893;
+			// aapt resource value: 0x7f0900ac
+			public const int TextAppearance_AppCompat_Headline = 2131296428;
 			
-			// aapt resource value: 0x7f0800ae
-			public const int TextAppearance_AppCompat_Large = 2131230894;
+			// aapt resource value: 0x7f0900ad
+			public const int TextAppearance_AppCompat_Inverse = 2131296429;
 			
-			// aapt resource value: 0x7f0800af
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131230895;
+			// aapt resource value: 0x7f0900ae
+			public const int TextAppearance_AppCompat_Large = 2131296430;
 			
-			// aapt resource value: 0x7f0800b0
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131230896;
+			// aapt resource value: 0x7f0900af
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131296431;
 			
-			// aapt resource value: 0x7f0800b1
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131230897;
+			// aapt resource value: 0x7f0900b0
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296432;
 			
-			// aapt resource value: 0x7f0800b2
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131230898;
+			// aapt resource value: 0x7f0900b1
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296433;
 			
-			// aapt resource value: 0x7f0800b3
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131230899;
+			// aapt resource value: 0x7f0900b2
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296434;
 			
-			// aapt resource value: 0x7f0800b4
-			public const int TextAppearance_AppCompat_Medium = 2131230900;
+			// aapt resource value: 0x7f0900b3
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296435;
 			
-			// aapt resource value: 0x7f0800b5
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131230901;
+			// aapt resource value: 0x7f0900b4
+			public const int TextAppearance_AppCompat_Medium = 2131296436;
 			
-			// aapt resource value: 0x7f0800b6
-			public const int TextAppearance_AppCompat_Menu = 2131230902;
+			// aapt resource value: 0x7f0900b5
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131296437;
 			
-			// aapt resource value: 0x7f0800b7
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131230903;
+			// aapt resource value: 0x7f0900b6
+			public const int TextAppearance_AppCompat_Menu = 2131296438;
 			
-			// aapt resource value: 0x7f0800b8
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131230904;
+			// aapt resource value: 0x7f0900b7
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296439;
 			
-			// aapt resource value: 0x7f0800b9
-			public const int TextAppearance_AppCompat_Small = 2131230905;
+			// aapt resource value: 0x7f0900b8
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131296440;
 			
-			// aapt resource value: 0x7f0800ba
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131230906;
+			// aapt resource value: 0x7f0900b9
+			public const int TextAppearance_AppCompat_Small = 2131296441;
 			
-			// aapt resource value: 0x7f0800bb
-			public const int TextAppearance_AppCompat_Subhead = 2131230907;
+			// aapt resource value: 0x7f0900ba
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131296442;
 			
-			// aapt resource value: 0x7f0800bc
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131230908;
+			// aapt resource value: 0x7f0900bb
+			public const int TextAppearance_AppCompat_Subhead = 2131296443;
 			
-			// aapt resource value: 0x7f0800bd
-			public const int TextAppearance_AppCompat_Title = 2131230909;
+			// aapt resource value: 0x7f0900bc
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131296444;
 			
-			// aapt resource value: 0x7f0800be
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131230910;
+			// aapt resource value: 0x7f0900bd
+			public const int TextAppearance_AppCompat_Title = 2131296445;
 			
-			// aapt resource value: 0x7f0800bf
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131230911;
+			// aapt resource value: 0x7f0900be
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131296446;
 			
-			// aapt resource value: 0x7f0800c0
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131230912;
+			// aapt resource value: 0x7f0900bf
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296447;
 			
-			// aapt resource value: 0x7f0800c1
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131230913;
+			// aapt resource value: 0x7f0900c0
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296448;
 			
-			// aapt resource value: 0x7f0800c2
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131230914;
+			// aapt resource value: 0x7f0900c1
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296449;
 			
-			// aapt resource value: 0x7f0800c3
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131230915;
+			// aapt resource value: 0x7f0900c2
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296450;
 			
-			// aapt resource value: 0x7f0800c4
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131230916;
+			// aapt resource value: 0x7f0900c3
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296451;
 			
-			// aapt resource value: 0x7f0800c5
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131230917;
+			// aapt resource value: 0x7f0900c4
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296452;
 			
-			// aapt resource value: 0x7f0800c6
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131230918;
+			// aapt resource value: 0x7f0900c5
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296453;
 			
-			// aapt resource value: 0x7f0800c7
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131230919;
+			// aapt resource value: 0x7f0900c6
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296454;
 			
-			// aapt resource value: 0x7f0800c8
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131230920;
+			// aapt resource value: 0x7f0900c7
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296455;
 			
-			// aapt resource value: 0x7f0800c9
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131230921;
+			// aapt resource value: 0x7f0900c8
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131296456;
 			
-			// aapt resource value: 0x7f0800ca
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131230922;
+			// aapt resource value: 0x7f0900c9
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296457;
 			
-			// aapt resource value: 0x7f0800cb
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131230923;
+			// aapt resource value: 0x7f0900ca
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296458;
 			
-			// aapt resource value: 0x7f0800cc
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131230924;
+			// aapt resource value: 0x7f0900cb
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131296459;
 			
-			// aapt resource value: 0x7f080126
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131231014;
+			// aapt resource value: 0x7f0900cc
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296460;
 			
-			// aapt resource value: 0x7f080127
-			public const int TextAppearance_Design_Error = 2131231015;
+			// aapt resource value: 0x7f090126
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131296550;
 			
-			// aapt resource value: 0x7f080128
-			public const int TextAppearance_Design_Hint = 2131231016;
+			// aapt resource value: 0x7f090127
+			public const int TextAppearance_Design_Error = 2131296551;
 			
-			// aapt resource value: 0x7f080129
-			public const int TextAppearance_Design_Snackbar_Action = 2131231017;
+			// aapt resource value: 0x7f090128
+			public const int TextAppearance_Design_Hint = 2131296552;
 			
-			// aapt resource value: 0x7f08012a
-			public const int TextAppearance_Design_Snackbar_Message = 2131231018;
+			// aapt resource value: 0x7f090129
+			public const int TextAppearance_Design_Snackbar_Action = 2131296553;
 			
-			// aapt resource value: 0x7f08012b
-			public const int TextAppearance_Design_Tab = 2131231019;
+			// aapt resource value: 0x7f09012a
+			public const int TextAppearance_Design_Snackbar_Message = 2131296554;
 			
-			// aapt resource value: 0x7f08001b
-			public const int TextAppearance_StatusBar_EventContent = 2131230747;
+			// aapt resource value: 0x7f09012b
+			public const int TextAppearance_Design_Tab = 2131296555;
 			
-			// aapt resource value: 0x7f08001c
-			public const int TextAppearance_StatusBar_EventContent_Info = 2131230748;
+			// aapt resource value: 0x7f09001b
+			public const int TextAppearance_StatusBar_EventContent = 2131296283;
 			
-			// aapt resource value: 0x7f08001d
-			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131230749;
+			// aapt resource value: 0x7f09001c
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131296284;
 			
-			// aapt resource value: 0x7f08001e
-			public const int TextAppearance_StatusBar_EventContent_Time = 2131230750;
+			// aapt resource value: 0x7f09001d
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131296285;
 			
-			// aapt resource value: 0x7f08001f
-			public const int TextAppearance_StatusBar_EventContent_Title = 2131230751;
+			// aapt resource value: 0x7f09001e
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131296286;
 			
-			// aapt resource value: 0x7f0800cd
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131230925;
+			// aapt resource value: 0x7f09001f
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131296287;
 			
-			// aapt resource value: 0x7f0800ce
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131230926;
+			// aapt resource value: 0x7f0900cd
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296461;
 			
-			// aapt resource value: 0x7f0800cf
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131230927;
+			// aapt resource value: 0x7f0900ce
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296462;
 			
-			// aapt resource value: 0x7f0800d0
-			public const int Theme_AppCompat = 2131230928;
+			// aapt resource value: 0x7f0900cf
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296463;
 			
-			// aapt resource value: 0x7f0800d1
-			public const int Theme_AppCompat_CompactMenu = 2131230929;
+			// aapt resource value: 0x7f0900d0
+			public const int Theme_AppCompat = 2131296464;
 			
-			// aapt resource value: 0x7f0800d2
-			public const int Theme_AppCompat_Dialog = 2131230930;
+			// aapt resource value: 0x7f0900d1
+			public const int Theme_AppCompat_CompactMenu = 2131296465;
 			
-			// aapt resource value: 0x7f0800d3
-			public const int Theme_AppCompat_Dialog_Alert = 2131230931;
+			// aapt resource value: 0x7f0900d2
+			public const int Theme_AppCompat_Dialog = 2131296466;
 			
-			// aapt resource value: 0x7f0800d4
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131230932;
+			// aapt resource value: 0x7f0900d3
+			public const int Theme_AppCompat_Dialog_Alert = 2131296467;
 			
-			// aapt resource value: 0x7f0800d5
-			public const int Theme_AppCompat_DialogWhenLarge = 2131230933;
+			// aapt resource value: 0x7f0900d4
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131296468;
 			
-			// aapt resource value: 0x7f0800d6
-			public const int Theme_AppCompat_Light = 2131230934;
+			// aapt resource value: 0x7f0900d5
+			public const int Theme_AppCompat_DialogWhenLarge = 2131296469;
 			
-			// aapt resource value: 0x7f0800d7
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131230935;
+			// aapt resource value: 0x7f0900d6
+			public const int Theme_AppCompat_Light = 2131296470;
 			
-			// aapt resource value: 0x7f0800d8
-			public const int Theme_AppCompat_Light_Dialog = 2131230936;
+			// aapt resource value: 0x7f0900d7
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131296471;
 			
-			// aapt resource value: 0x7f0800d9
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131230937;
+			// aapt resource value: 0x7f0900d8
+			public const int Theme_AppCompat_Light_Dialog = 2131296472;
 			
-			// aapt resource value: 0x7f0800da
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131230938;
+			// aapt resource value: 0x7f0900d9
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131296473;
 			
-			// aapt resource value: 0x7f0800db
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131230939;
+			// aapt resource value: 0x7f0900da
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131296474;
 			
-			// aapt resource value: 0x7f0800dc
-			public const int Theme_AppCompat_Light_NoActionBar = 2131230940;
+			// aapt resource value: 0x7f0900db
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131296475;
 			
-			// aapt resource value: 0x7f0800dd
-			public const int Theme_AppCompat_NoActionBar = 2131230941;
+			// aapt resource value: 0x7f0900dc
+			public const int Theme_AppCompat_Light_NoActionBar = 2131296476;
 			
-			// aapt resource value: 0x7f0800de
-			public const int ThemeOverlay_AppCompat = 2131230942;
+			// aapt resource value: 0x7f0900dd
+			public const int Theme_AppCompat_NoActionBar = 2131296477;
 			
-			// aapt resource value: 0x7f0800df
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131230943;
+			// aapt resource value: 0x7f0900de
+			public const int ThemeOverlay_AppCompat = 2131296478;
 			
-			// aapt resource value: 0x7f0800e0
-			public const int ThemeOverlay_AppCompat_Dark = 2131230944;
+			// aapt resource value: 0x7f0900df
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131296479;
 			
-			// aapt resource value: 0x7f0800e1
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131230945;
+			// aapt resource value: 0x7f0900e0
+			public const int ThemeOverlay_AppCompat_Dark = 2131296480;
 			
-			// aapt resource value: 0x7f0800e2
-			public const int ThemeOverlay_AppCompat_Light = 2131230946;
+			// aapt resource value: 0x7f0900e1
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296481;
 			
-			// aapt resource value: 0x7f0800e3
-			public const int Widget_AppCompat_ActionBar = 2131230947;
+			// aapt resource value: 0x7f0900e2
+			public const int ThemeOverlay_AppCompat_Light = 2131296482;
 			
-			// aapt resource value: 0x7f0800e4
-			public const int Widget_AppCompat_ActionBar_Solid = 2131230948;
+			// aapt resource value: 0x7f0900e3
+			public const int Widget_AppCompat_ActionBar = 2131296483;
 			
-			// aapt resource value: 0x7f0800e5
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131230949;
+			// aapt resource value: 0x7f0900e4
+			public const int Widget_AppCompat_ActionBar_Solid = 2131296484;
 			
-			// aapt resource value: 0x7f0800e6
-			public const int Widget_AppCompat_ActionBar_TabText = 2131230950;
+			// aapt resource value: 0x7f0900e5
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131296485;
 			
-			// aapt resource value: 0x7f0800e7
-			public const int Widget_AppCompat_ActionBar_TabView = 2131230951;
+			// aapt resource value: 0x7f0900e6
+			public const int Widget_AppCompat_ActionBar_TabText = 2131296486;
 			
-			// aapt resource value: 0x7f0800e8
-			public const int Widget_AppCompat_ActionButton = 2131230952;
+			// aapt resource value: 0x7f0900e7
+			public const int Widget_AppCompat_ActionBar_TabView = 2131296487;
 			
-			// aapt resource value: 0x7f0800e9
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131230953;
+			// aapt resource value: 0x7f0900e8
+			public const int Widget_AppCompat_ActionButton = 2131296488;
 			
-			// aapt resource value: 0x7f0800ea
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131230954;
+			// aapt resource value: 0x7f0900e9
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131296489;
 			
-			// aapt resource value: 0x7f0800eb
-			public const int Widget_AppCompat_ActionMode = 2131230955;
+			// aapt resource value: 0x7f0900ea
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131296490;
 			
-			// aapt resource value: 0x7f0800ec
-			public const int Widget_AppCompat_ActivityChooserView = 2131230956;
+			// aapt resource value: 0x7f0900eb
+			public const int Widget_AppCompat_ActionMode = 2131296491;
 			
-			// aapt resource value: 0x7f0800ed
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131230957;
+			// aapt resource value: 0x7f0900ec
+			public const int Widget_AppCompat_ActivityChooserView = 2131296492;
 			
-			// aapt resource value: 0x7f0800ee
-			public const int Widget_AppCompat_Button = 2131230958;
+			// aapt resource value: 0x7f0900ed
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131296493;
 			
-			// aapt resource value: 0x7f0800ef
-			public const int Widget_AppCompat_Button_Borderless = 2131230959;
+			// aapt resource value: 0x7f0900ee
+			public const int Widget_AppCompat_Button = 2131296494;
 			
-			// aapt resource value: 0x7f0800f0
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131230960;
+			// aapt resource value: 0x7f0900ef
+			public const int Widget_AppCompat_Button_Borderless = 2131296495;
 			
-			// aapt resource value: 0x7f0800f1
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131230961;
+			// aapt resource value: 0x7f0900f0
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131296496;
 			
-			// aapt resource value: 0x7f0800f2
-			public const int Widget_AppCompat_Button_Small = 2131230962;
+			// aapt resource value: 0x7f0900f1
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296497;
 			
-			// aapt resource value: 0x7f0800f3
-			public const int Widget_AppCompat_ButtonBar = 2131230963;
+			// aapt resource value: 0x7f0900f2
+			public const int Widget_AppCompat_Button_Small = 2131296498;
 			
-			// aapt resource value: 0x7f0800f4
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131230964;
+			// aapt resource value: 0x7f0900f3
+			public const int Widget_AppCompat_ButtonBar = 2131296499;
 			
-			// aapt resource value: 0x7f0800f5
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131230965;
+			// aapt resource value: 0x7f0900f4
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131296500;
 			
-			// aapt resource value: 0x7f0800f6
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131230966;
+			// aapt resource value: 0x7f0900f5
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131296501;
 			
-			// aapt resource value: 0x7f0800f7
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131230967;
+			// aapt resource value: 0x7f0900f6
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131296502;
 			
-			// aapt resource value: 0x7f0800f8
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131230968;
+			// aapt resource value: 0x7f0900f7
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131296503;
 			
-			// aapt resource value: 0x7f0800f9
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131230969;
+			// aapt resource value: 0x7f0900f8
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131296504;
 			
-			// aapt resource value: 0x7f0800fa
-			public const int Widget_AppCompat_EditText = 2131230970;
+			// aapt resource value: 0x7f0900f9
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131296505;
 			
-			// aapt resource value: 0x7f0800fb
-			public const int Widget_AppCompat_Light_ActionBar = 2131230971;
+			// aapt resource value: 0x7f0900fa
+			public const int Widget_AppCompat_EditText = 2131296506;
 			
-			// aapt resource value: 0x7f0800fc
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131230972;
+			// aapt resource value: 0x7f0900fb
+			public const int Widget_AppCompat_Light_ActionBar = 2131296507;
 			
-			// aapt resource value: 0x7f0800fd
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131230973;
+			// aapt resource value: 0x7f0900fc
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131296508;
 			
-			// aapt resource value: 0x7f0800fe
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131230974;
+			// aapt resource value: 0x7f0900fd
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296509;
 			
-			// aapt resource value: 0x7f0800ff
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131230975;
+			// aapt resource value: 0x7f0900fe
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131296510;
 			
-			// aapt resource value: 0x7f080100
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131230976;
+			// aapt resource value: 0x7f0900ff
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296511;
 			
-			// aapt resource value: 0x7f080101
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131230977;
+			// aapt resource value: 0x7f090100
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131296512;
 			
-			// aapt resource value: 0x7f080102
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131230978;
+			// aapt resource value: 0x7f090101
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296513;
 			
-			// aapt resource value: 0x7f080103
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131230979;
+			// aapt resource value: 0x7f090102
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131296514;
 			
-			// aapt resource value: 0x7f080104
-			public const int Widget_AppCompat_Light_ActionButton = 2131230980;
+			// aapt resource value: 0x7f090103
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296515;
 			
-			// aapt resource value: 0x7f080105
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131230981;
+			// aapt resource value: 0x7f090104
+			public const int Widget_AppCompat_Light_ActionButton = 2131296516;
 			
-			// aapt resource value: 0x7f080106
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131230982;
+			// aapt resource value: 0x7f090105
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296517;
 			
-			// aapt resource value: 0x7f080107
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131230983;
+			// aapt resource value: 0x7f090106
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131296518;
 			
-			// aapt resource value: 0x7f080108
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131230984;
+			// aapt resource value: 0x7f090107
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131296519;
 			
-			// aapt resource value: 0x7f080109
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131230985;
+			// aapt resource value: 0x7f090108
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131296520;
 			
-			// aapt resource value: 0x7f08010a
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131230986;
+			// aapt resource value: 0x7f090109
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131296521;
 			
-			// aapt resource value: 0x7f08010b
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131230987;
+			// aapt resource value: 0x7f09010a
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296522;
 			
-			// aapt resource value: 0x7f08010c
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131230988;
+			// aapt resource value: 0x7f09010b
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131296523;
 			
-			// aapt resource value: 0x7f08010d
-			public const int Widget_AppCompat_Light_PopupMenu = 2131230989;
+			// aapt resource value: 0x7f09010c
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131296524;
 			
-			// aapt resource value: 0x7f08010e
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131230990;
+			// aapt resource value: 0x7f09010d
+			public const int Widget_AppCompat_Light_PopupMenu = 2131296525;
 			
-			// aapt resource value: 0x7f08010f
-			public const int Widget_AppCompat_Light_SearchView = 2131230991;
+			// aapt resource value: 0x7f09010e
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296526;
 			
-			// aapt resource value: 0x7f080110
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131230992;
+			// aapt resource value: 0x7f09010f
+			public const int Widget_AppCompat_Light_SearchView = 2131296527;
 			
-			// aapt resource value: 0x7f080111
-			public const int Widget_AppCompat_ListPopupWindow = 2131230993;
+			// aapt resource value: 0x7f090110
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296528;
 			
-			// aapt resource value: 0x7f080112
-			public const int Widget_AppCompat_ListView = 2131230994;
+			// aapt resource value: 0x7f090111
+			public const int Widget_AppCompat_ListPopupWindow = 2131296529;
 			
-			// aapt resource value: 0x7f080113
-			public const int Widget_AppCompat_ListView_DropDown = 2131230995;
+			// aapt resource value: 0x7f090112
+			public const int Widget_AppCompat_ListView = 2131296530;
 			
-			// aapt resource value: 0x7f080114
-			public const int Widget_AppCompat_ListView_Menu = 2131230996;
+			// aapt resource value: 0x7f090113
+			public const int Widget_AppCompat_ListView_DropDown = 2131296531;
 			
-			// aapt resource value: 0x7f080115
-			public const int Widget_AppCompat_PopupMenu = 2131230997;
+			// aapt resource value: 0x7f090114
+			public const int Widget_AppCompat_ListView_Menu = 2131296532;
 			
-			// aapt resource value: 0x7f080116
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131230998;
+			// aapt resource value: 0x7f090115
+			public const int Widget_AppCompat_PopupMenu = 2131296533;
 			
-			// aapt resource value: 0x7f080117
-			public const int Widget_AppCompat_PopupWindow = 2131230999;
+			// aapt resource value: 0x7f090116
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131296534;
 			
-			// aapt resource value: 0x7f080118
-			public const int Widget_AppCompat_ProgressBar = 2131231000;
+			// aapt resource value: 0x7f090117
+			public const int Widget_AppCompat_PopupWindow = 2131296535;
 			
-			// aapt resource value: 0x7f080119
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131231001;
+			// aapt resource value: 0x7f090118
+			public const int Widget_AppCompat_ProgressBar = 2131296536;
 			
-			// aapt resource value: 0x7f08011a
-			public const int Widget_AppCompat_RatingBar = 2131231002;
+			// aapt resource value: 0x7f090119
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131296537;
 			
-			// aapt resource value: 0x7f08011b
-			public const int Widget_AppCompat_SearchView = 2131231003;
+			// aapt resource value: 0x7f09011a
+			public const int Widget_AppCompat_RatingBar = 2131296538;
 			
-			// aapt resource value: 0x7f08011c
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131231004;
+			// aapt resource value: 0x7f09011b
+			public const int Widget_AppCompat_SearchView = 2131296539;
 			
-			// aapt resource value: 0x7f08011d
-			public const int Widget_AppCompat_Spinner = 2131231005;
+			// aapt resource value: 0x7f09011c
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131296540;
 			
-			// aapt resource value: 0x7f08011e
-			public const int Widget_AppCompat_Spinner_DropDown = 2131231006;
+			// aapt resource value: 0x7f09011d
+			public const int Widget_AppCompat_Spinner = 2131296541;
 			
-			// aapt resource value: 0x7f08011f
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131231007;
+			// aapt resource value: 0x7f09011e
+			public const int Widget_AppCompat_Spinner_DropDown = 2131296542;
 			
-			// aapt resource value: 0x7f080120
-			public const int Widget_AppCompat_Spinner_Underlined = 2131231008;
+			// aapt resource value: 0x7f09011f
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296543;
 			
-			// aapt resource value: 0x7f080121
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131231009;
+			// aapt resource value: 0x7f090120
+			public const int Widget_AppCompat_Spinner_Underlined = 2131296544;
 			
-			// aapt resource value: 0x7f080122
-			public const int Widget_AppCompat_Toolbar = 2131231010;
+			// aapt resource value: 0x7f090121
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131296545;
 			
-			// aapt resource value: 0x7f080123
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131231011;
+			// aapt resource value: 0x7f090122
+			public const int Widget_AppCompat_Toolbar = 2131296546;
 			
-			// aapt resource value: 0x7f08012c
-			public const int Widget_Design_AppBarLayout = 2131231020;
+			// aapt resource value: 0x7f090123
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131296547;
 			
-			// aapt resource value: 0x7f08012d
-			public const int Widget_Design_CollapsingToolbar = 2131231021;
+			// aapt resource value: 0x7f09012c
+			public const int Widget_Design_AppBarLayout = 2131296556;
 			
-			// aapt resource value: 0x7f08012e
-			public const int Widget_Design_CoordinatorLayout = 2131231022;
+			// aapt resource value: 0x7f09012d
+			public const int Widget_Design_CollapsingToolbar = 2131296557;
 			
-			// aapt resource value: 0x7f08012f
-			public const int Widget_Design_FloatingActionButton = 2131231023;
+			// aapt resource value: 0x7f09012e
+			public const int Widget_Design_CoordinatorLayout = 2131296558;
 			
-			// aapt resource value: 0x7f080130
-			public const int Widget_Design_NavigationView = 2131231024;
+			// aapt resource value: 0x7f09012f
+			public const int Widget_Design_FloatingActionButton = 2131296559;
 			
-			// aapt resource value: 0x7f080131
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131231025;
+			// aapt resource value: 0x7f090130
+			public const int Widget_Design_NavigationView = 2131296560;
 			
-			// aapt resource value: 0x7f080132
-			public const int Widget_Design_Snackbar = 2131231026;
+			// aapt resource value: 0x7f090131
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131296561;
 			
-			// aapt resource value: 0x7f080124
-			public const int Widget_Design_TabLayout = 2131231012;
+			// aapt resource value: 0x7f090132
+			public const int Widget_Design_Snackbar = 2131296562;
 			
-			// aapt resource value: 0x7f080133
-			public const int Widget_Design_TextInputLayout = 2131231027;
+			// aapt resource value: 0x7f090124
+			public const int Widget_Design_TabLayout = 2131296548;
+			
+			// aapt resource value: 0x7f090133
+			public const int Widget_Design_TextInputLayout = 2131296563;
 			
 			static Style()
 			{
@@ -3360,6 +3366,25 @@ namespace Example.Droid
 			}
 			
 			private Style()
+			{
+			}
+		}
+		
+		public partial class Transition
+		{
+			
+			// aapt resource value: 0x7f050000
+			public const int slide_left = 2131034112;
+			
+			// aapt resource value: 0x7f050001
+			public const int slide_right = 2131034113;
+			
+			static Transition()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Transition()
 			{
 			}
 		}

--- a/Samples/Example.Droid/Resources/transition/slide_left.xml
+++ b/Samples/Example.Droid/Resources/transition/slide_left.xml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8" ?> 
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:slideEdge="left" />

--- a/Samples/Example.Droid/Resources/transition/slide_right.xml
+++ b/Samples/Example.Droid/Resources/transition/slide_right.xml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<slide xmlns:android="http://schemas.android.com/apk/res/android"
+    android:slideEdge="right" />


### PR DESCRIPTION
Fixed:
- Fragments where always being re-instantiated, the cache was never being used (check attached image)
- Possible edge case that would happen if we tried to show a previously cached fragment that wasn't in the FragmentManager, Attach would fail. It's now replacing anything.

![mvvmcross_bug](https://cloud.githubusercontent.com/assets/542036/10123475/3fcdf1b4-6532-11e5-86db-ac55ba734b04.png)
