### PR TITLE
MvxPreferenceFragmentCompat

### DIFF
--- a/Cirrious.MvvmCross.Droid.Support.Preference/Cirrious.MvvmCross.Droid.Support.Preference.csproj
+++ b/Cirrious.MvvmCross.Droid.Support.Preference/Cirrious.MvvmCross.Droid.Support.Preference.csproj
@@ -86,6 +86,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MvxEventSourcePreferenceFragmentCompat.cs" />
+    <Compile Include="MvxPreferenceFragmentCompat.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MvxPreferenceFragment.cs" />
     <Compile Include="MvxEventSourcePreferenceFragment.cs" />

--- a/Cirrious.MvvmCross.Droid.Support.Preference/MvxEventSourcePreferenceFragmentCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Preference/MvxEventSourcePreferenceFragmentCompat.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.Support.V7.Preferences;
+using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments.EventSource;
+using Cirrious.CrossCore.Core;
+using Cirrious.MvvmCross.Droid.Support.Fragging;
+
+namespace Cirrious.MvvmCross.Droid.Support.Preference
+{
+    public abstract class MvxEventSourcePreferenceFragmentCompat : PreferenceFragmentCompat
+    , IMvxEventSourceFragment
+    {
+        public event EventHandler<MvxValueEventArgs<Activity>> AttachCalled;
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateWillBeCalled;
+        public event EventHandler<MvxValueEventArgs<Bundle>> CreateCalled;
+        public event EventHandler<MvxValueEventArgs<MvxCreateViewParameters>> CreateViewCalled;
+        public event EventHandler StartCalled;
+        public event EventHandler ResumeCalled;
+        public event EventHandler PauseCalled;
+        public event EventHandler StopCalled;
+        public event EventHandler DestroyViewCalled;
+        public event EventHandler DestroyCalled;
+        public event EventHandler DetachCalled;
+
+        public event EventHandler DisposeCalled;
+        public event EventHandler<MvxValueEventArgs<Bundle>> SaveInstanceStateCalled;
+
+        public MvxEventSourcePreferenceFragmentCompat()
+        {
+
+        }
+
+        public MvxEventSourcePreferenceFragmentCompat(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+
+        }
+
+        public override void OnAttach(Activity activity)
+        {
+            AttachCalled.Raise(this, Activity);
+            base.OnAttach(activity);
+        }
+
+        public override void OnCreate(Bundle savedInstanceState)
+        {
+            CreateWillBeCalled.Raise(this, savedInstanceState);
+            base.OnCreate(savedInstanceState);
+            CreateCalled.Raise(this, savedInstanceState);
+        }
+
+        public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+        {
+            CreateViewCalled.Raise(this, new MvxCreateViewParameters(inflater, container, savedInstanceState));
+            return base.OnCreateView(inflater, container, savedInstanceState);
+        }
+
+        public override void OnStart()
+        {
+            StartCalled.Raise(this);
+            base.OnStart();
+        }
+
+        public override void OnResume()
+        {
+            ResumeCalled.Raise(this);
+            base.OnResume();
+        }
+
+        public override void OnPause()
+        {
+            PauseCalled.Raise(this);
+            base.OnPause();
+        }
+
+        public override void OnStop()
+        {
+            StopCalled.Raise(this);
+            base.OnStop();
+        }
+
+        public override void OnDestroyView()
+        {
+            DestroyViewCalled.Raise(this);
+            base.OnDestroyView();
+        }
+
+        public override void OnDestroy()
+        {
+            DestroyCalled.Raise(this);
+            base.OnDestroy();
+        }
+
+        public override void OnDetach()
+        {
+            DetachCalled.Raise(this);
+            base.OnDetach();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCalled.Raise(this);
+            }
+            base.Dispose(disposing);
+        }
+
+        public override void OnSaveInstanceState(Bundle outState)
+        {
+            SaveInstanceStateCalled.Raise(this, outState);
+            base.OnSaveInstanceState(outState);
+        }
+    }
+}

--- a/Cirrious.MvvmCross.Droid.Support.Preference/MvxEventSourcePreferenceFragmentCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Preference/MvxEventSourcePreferenceFragmentCompat.cs
@@ -1,18 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 using Android.App;
-using Android.Content;
 using Android.OS;
 using Android.Runtime;
-using Android.Views;
-using Android.Widget;
 using Android.Support.V7.Preferences;
-using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments.EventSource;
+using Android.Views;
 using Cirrious.CrossCore.Core;
 using Cirrious.MvvmCross.Droid.Support.Fragging;
+using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments.EventSource;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.Support.Preference
 {

--- a/Cirrious.MvvmCross.Droid.Support.Preference/MvxPreferenceFragmentCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Preference/MvxPreferenceFragmentCompat.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments;
+using Cirrious.MvvmCross.ViewModels;
+using Cirrious.MvvmCross.Binding.BindingContext;
+
+namespace Cirrious.MvvmCross.Droid.Support.Preference
+{
+    public abstract class MvxPreferenceFragmentCompat : MvxEventSourcePreferenceFragmentCompat, IMvxFragmentView
+    {
+        protected MvxPreferenceFragmentCompat()
+        {
+            this.AddEventListeners();
+        }
+
+        protected MvxPreferenceFragmentCompat(IntPtr javaReference, JniHandleOwnership transfer)
+			: base(javaReference, transfer)
+		{
+            this.AddEventListeners();
+        }
+
+        public IMvxBindingContext BindingContext { get; set; }
+
+        private object _dataContext;
+
+        public object DataContext
+        {
+            get { return _dataContext; }
+            set
+            {
+                _dataContext = value;
+                if (BindingContext != null)
+                    BindingContext.DataContext = value;
+            }
+        }
+
+        public virtual IMvxViewModel ViewModel
+        {
+            get { return DataContext as IMvxViewModel; }
+            set
+            {
+                DataContext = value;
+                OnViewModelSet();
+            }
+        }
+
+        public virtual void OnViewModelSet()
+        {
+        }
+
+        public string UniqueImmutableCacheTag => Tag;
+    }
+
+    public abstract class MvxPreferenceFragmentCompat<TViewModel>
+        : MvxPreferenceFragment
+    , IMvxFragmentView<TViewModel> where TViewModel : class, IMvxViewModel
+    {
+
+        protected MvxPreferenceFragmentCompat()
+        {
+
+        }
+
+        protected MvxPreferenceFragmentCompat(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
+
+
+        public new TViewModel ViewModel
+        {
+            get { return (TViewModel)base.ViewModel; }
+            set { base.ViewModel = value; }
+        }
+    }
+}
+}

--- a/Cirrious.MvvmCross.Droid.Support.Preference/MvxPreferenceFragmentCompat.cs
+++ b/Cirrious.MvvmCross.Droid.Support.Preference/MvxPreferenceFragmentCompat.cs
@@ -1,17 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using Android.App;
-using Android.Content;
-using Android.OS;
 using Android.Runtime;
-using Android.Views;
-using Android.Widget;
+using Cirrious.MvvmCross.Binding.BindingContext;
 using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments;
 using Cirrious.MvvmCross.ViewModels;
-using Cirrious.MvvmCross.Binding.BindingContext;
+using System;
 
 namespace Cirrious.MvvmCross.Droid.Support.Preference
 {

--- a/Cirrious.MvvmCross.Droid.Support.V4/MvxFragmentStatePagerAdapter.cs
+++ b/Cirrious.MvvmCross.Droid.Support.V4/MvxFragmentStatePagerAdapter.cs
@@ -16,6 +16,7 @@ using Cirrious.CrossCore;
 using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments;
 using Cirrious.MvvmCross.ViewModels;
 using Java.Lang;
+using Cirrious.MvvmCross.Views;
 
 namespace Cirrious.MvvmCross.Droid.Support.V4
 {
@@ -49,7 +50,7 @@ namespace Cirrious.MvvmCross.Droid.Support.V4
                 fragInfo.CachedFragment = Fragment.Instantiate(_context, FragmentJavaName(fragInfo.FragmentType));
 
                 var request = new MvxViewModelRequest (fragInfo.ViewModelType, null, null, null);
-                ((MvxFragment)fragInfo.CachedFragment).ViewModel = Mvx.Resolve<IMvxViewModelLoader>().LoadViewModel(request, null);
+                ((IMvxView)fragInfo.CachedFragment).ViewModel = Mvx.Resolve<IMvxViewModelLoader>().LoadViewModel(request, null);
             }
 
             return fragInfo.CachedFragment;

--- a/Cirrious.MvvmCross.Droid.Support.V4/MvxFragmentStatePagerAdapter.cs
+++ b/Cirrious.MvvmCross.Droid.Support.V4/MvxFragmentStatePagerAdapter.cs
@@ -5,18 +5,17 @@
 // 
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.App;
 using Cirrious.CrossCore;
-using Cirrious.MvvmCross.Droid.Support.Fragging.Fragments;
 using Cirrious.MvvmCross.ViewModels;
-using Java.Lang;
 using Cirrious.MvvmCross.Views;
+using Java.Lang;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Cirrious.MvvmCross.Droid.Support.V4
 {


### PR DESCRIPTION
Introduce the MvxPreferenceFragmentCompat class. Direct copy of MvxPreferenceFragment, except it inherits from the support version instead, PreferenceFragmentCompat. Change cast in MvxFragmentStatePagerAdapter to allow using MvxPreferenceFragmentCompat in a viewpager. Resolves #109
