### PR TITLE
added useful comment in the Setup class

### DIFF
--- a/Samples/Example.Droid/Setup.cs
+++ b/Samples/Example.Droid/Setup.cs
@@ -36,7 +36,8 @@ namespace Example.Droid
 
         protected override IMvxAndroidViewPresenter CreateViewPresenter()
         {
-			return new MvxFragmentsPresenter(AndroidViewAssemblies);
+            //This is very important to override. The default view presenter does not know how to show fragments!
+            return new MvxFragmentsPresenter(AndroidViewAssemblies);
         }
 
         protected override IMvxTrace CreateDebugTrace()


### PR DESCRIPTION
 The default view presenter does not know how to show fragments and that's why in the Setup class we need to override the CreateViewPresenter
