### PR TITLE
Fixed a minor issue in the example. 

### DIFF
--- a/Samples/Example.Droid/Activities/Caching/MainActivityFragmentCacheInfoFactory.cs
+++ b/Samples/Example.Droid/Activities/Caching/MainActivityFragmentCacheInfoFactory.cs
@@ -80,8 +80,8 @@ namespace Example.Droid.Activities.Caching
             var baseCachedFragmentInfo = base.ConvertSerializableFragmentInfo(fromSerializableMvxCachedFragmentInfo);
 
             return new CustomFragmentInfo(baseCachedFragmentInfo.Tag, baseCachedFragmentInfo.FragmentType,
-                baseCachedFragmentInfo.ViewModelType, baseCachedFragmentInfo.AddToBackStack,
-                serializableCustomFragmentInfo?.IsRoot ?? false)
+				baseCachedFragmentInfo.ViewModelType, baseCachedFragmentInfo.CacheFragment, 
+				baseCachedFragmentInfo.AddToBackStack, serializableCustomFragmentInfo?.IsRoot ?? false)
             {
                 ContentId = baseCachedFragmentInfo.ContentId,
                 CachedFragment = baseCachedFragmentInfo.CachedFragment


### PR DESCRIPTION
The CacheFragment property was never used in the ConvertSerializableFragmentInfo method.
The AddToBackStack property was passed as the CacheFragment property
