### PR TITLE
Fix bug when  Android does auto memory management.

### DIFF
--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -60,6 +60,16 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             this.AddEventListeners();
         }
 
+        protected override void OnCreate(Bundle bundle)
+        {
+            // Prevents crash when activity in background with history enable is reopened after 
+            // Android does some auto memory management.
+            var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(this);
+            setup.EnsureInitialized();
+
+            base.OnCreate(bundle);
+        }
+
         protected override void OnPostCreate(Bundle savedInstanceState)
         {
             base.OnPostCreate(savedInstanceState);


### PR DESCRIPTION
This was tested with Android 5.0.2, 1G of Ram and the bug was forced scrolling down Facebook and Chrome Apps for some seconds until Android does some memory management.

MvxAppCompatActivity probably needs this too.
