### PR TITLE
Close activity if last fragment removed on back button pressed

### DIFF
--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -308,7 +308,10 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
                     OnFragmentPopped(currentFragsInfo);
                 }
 
-                return;
+                if (0 != SupportFragmentManager.BackStackEntryCount)
+                {
+                    return;
+                }
             }
 
             base.OnBackPressed();

--- a/MvvmCross.Droid.Support.V7.Fragging/Caching/MvxCachingFragmentActivity.cs
+++ b/MvvmCross.Droid.Support.V7.Fragging/Caching/MvxCachingFragmentActivity.cs
@@ -297,7 +297,10 @@ namespace MvvmCross.Droid.Support.V7.Fragging.Caching
 					OnFragmentPopped(currentFragsInfo);
 				}
 
-				return;
+                if (0 != SupportFragmentManager.BackStackEntryCount)
+                {
+                    return;
+                }
 			}
 
 			base.OnBackPressed();


### PR DESCRIPTION
WIth the current implementation (in the demo app for example), when we press the back button removing the last fragment, doesn't close the activity (keeping the app opened with an "empty activity").

You can easily reproduce this behavior pressing the back button right after the application started.

This PR simply let the event propagate to parent class in the case we just removed the last fragment
