### PR TITLE
ACW constructors should only pass the java reference to the base

### DIFF
--- a/MvvmCross.Droid.Support.V14.Preference/MvxPreferenceFragment.cs
+++ b/MvvmCross.Droid.Support.V14.Preference/MvxPreferenceFragment.cs
@@ -19,9 +19,7 @@ namespace MvvmCross.Droid.Support.V14.Preference
 
 		protected MvxPreferenceFragment(IntPtr javaReference, JniHandleOwnership transfer)
 			: base(javaReference, transfer)
-		{
-			this.AddEventListeners();
-		}
+		{}
 
 		public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Adapters/MvxBaseObjectAdapter.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Adapters/MvxBaseObjectAdapter.cs
@@ -84,13 +84,8 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Adapters
             BindingContext = bindingContext;
         }
 
-        protected MvxBaseObjectAdapter(IntPtr javaReference, JniHandleOwnership transfer) : this(MvxAndroidBindingContextHelpers.Current(), javaReference, transfer)
+        protected MvxBaseObjectAdapter(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
         {
-        }
-
-        protected MvxBaseObjectAdapter(IMvxAndroidBindingContext bindingContext, IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
-        {
-            BindingContext = bindingContext;
         }
 
         protected virtual void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxBrowseSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxBrowseSupportFragment.cs
@@ -34,9 +34,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxBrowseSupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxDetailsSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxDetailsSupportFragment.cs
@@ -35,9 +35,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxDetailsSupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxGuidedStepSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxGuidedStepSupportFragment.cs
@@ -35,9 +35,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxGuidedStepSupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxHeadersSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxHeadersSupportFragment.cs
@@ -35,9 +35,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxHeadersSupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxPlaybackOverlaySupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxPlaybackOverlaySupportFragment.cs
@@ -35,9 +35,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxPlaybackOverlaySupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxRowsSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxRowsSupportFragment.cs
@@ -34,9 +34,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxRowsSupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxSearchSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/MvxSearchSupportFragment.cs
@@ -35,9 +35,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments
 
         protected MvxSearchSupportFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V4/MvxCachingFragmentActivity.cs
+++ b/MvvmCross.Droid.Support.V4/MvxCachingFragmentActivity.cs
@@ -46,10 +46,7 @@ namespace MvvmCross.Droid.Support.V4
 
 		protected MvxCachingFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer)
 			: base(javaReference, transfer)
-		{
-			BindingContext = new MvxAndroidBindingContext(this, this);
-			this.AddEventListeners();
-		}
+		{}
 
 		protected override void OnPostCreate(Bundle savedInstanceState)
 		{

--- a/MvvmCross.Droid.Support.V4/MvxDialogFragment.cs
+++ b/MvvmCross.Droid.Support.V4/MvxDialogFragment.cs
@@ -26,9 +26,7 @@ namespace MvvmCross.Droid.Support.V4
 
         protected MvxDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V4/MvxFragment.cs
+++ b/MvvmCross.Droid.Support.V4/MvxFragment.cs
@@ -40,9 +40,7 @@ namespace MvvmCross.Droid.Support.V4
 
         protected MvxFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V4/MvxFragmentActivity.cs
+++ b/MvvmCross.Droid.Support.V4/MvxFragmentActivity.cs
@@ -29,10 +29,7 @@ namespace MvvmCross.Droid.Support.V4
 
         protected MvxFragmentActivity(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            BindingContext = new MvxAndroidBindingContext(this, this);
-            this.AddEventListeners();
-        }
+        {}
 
         public object DataContext
         {

--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatActivity.cs
@@ -31,10 +31,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected MvxAppCompatActivity(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            BindingContext = new MvxAndroidBindingContext(this, this);
-            this.AddEventListeners();
-        }
+        {}
 
         public object DataContext
         {

--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatDialogFragment.cs
@@ -27,9 +27,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected MvxAppCompatDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            this.AddEventListeners();
-        }
+        {}
 
         public IMvxBindingContext BindingContext { get; set; }
 

--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -55,10 +55,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected MvxCachingFragmentCompatActivity(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            BindingContext = new MvxAndroidBindingContext(this, this);
-            this.AddEventListeners();
-        }
+        {}
 
         protected override void OnPostCreate(Bundle savedInstanceState)
         {

--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxFragmentCompatActivity.cs
@@ -37,10 +37,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         protected MvxFragmentCompatActivity(IntPtr javaReference, JniHandleOwnership transfer)
             : base(javaReference, transfer)
-        {
-            BindingContext = new MvxAndroidBindingContext(this, this);
-            this.AddEventListeners();
-        }
+        {}
 
         public object DataContext
         {

--- a/MvvmCross.Droid.Support.V7.Preference/MvxPreferenceFragmentCompat.cs
+++ b/MvvmCross.Droid.Support.V7.Preference/MvxPreferenceFragmentCompat.cs
@@ -17,9 +17,7 @@ namespace MvvmCross.Droid.Support.V7.Preference
 
         protected MvxPreferenceFragmentCompat(IntPtr javaReference, JniHandleOwnership transfer)
 			: base(javaReference, transfer)
-		{
-            this.AddEventListeners();
-        }
+		{}
 
         public IMvxBindingContext BindingContext { get; set; }
 


### PR DESCRIPTION
Support's version of MvvmCross/MvvmCross#1286
