### PR TITLE
Use GetItem method on DataContext initializaiton

### DIFF
--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -152,7 +152,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
         public override void OnBindViewHolder(Android.Support.V7.Widget.RecyclerView.ViewHolder holder, int position)
         {
-            ((IMvxRecyclerViewHolder)holder).DataContext = _itemsSource.ElementAt(position);
+            ((IMvxRecyclerViewHolder)holder).DataContext = GetItem(position);
         }
 
         public override int ItemCount => _itemsSource.Count();


### PR DESCRIPTION
There is no reason to not use the `GetItem` method  to initialize the `DataContext` especially if we use an adapter where `GetItem` method is overrided.
