### PR TITLE
Call MvxAppCompatSetupHelper.FillDefaultBindingNames

### DIFF
--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatSetup.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxAppCompatSetup.cs
@@ -45,6 +45,12 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 			MvxAppCompatSetupHelper.FillTargetFactories(registry);
 			base.FillTargetFactories(registry);
 		}
+
+		protected override void FillBindingNames(IMvxBindingNameRegistry registry)
+		{
+			MvxAppCompatSetupHelper.FillDefaultBindingNames(registry);
+			base.FillBindingNames(registry);
+		}
 	}
 }
 


### PR DESCRIPTION
Install AppCompat's binding names so `SearchViewCompat`, `MvxAppCompatListView` and `MvxappCompatImageView` work out of the box.
