### PR TITLE
Simplify event invocation

### DIFF
--- a/MvvmCross.Droid.Support.V17.Leanback/Adapters/MvxBaseObjectAdapter.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Adapters/MvxBaseObjectAdapter.cs
@@ -131,8 +131,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Adapters
 
         private void RaiseDataSetChanged()
         {
-            var handler = DataSetChanged;
-            handler?.Invoke(this, EventArgs.Empty);
+            DataSetChanged?.Invoke(this, EventArgs.Empty);
         }
 
         private void NotifyAndRaiseDataSetChanged()

--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxActionBarDrawerToggle.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxActionBarDrawerToggle.cs
@@ -70,32 +70,28 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 
         public override void OnDrawerClosed(View drawerView)
         {
-            var handler = DrawerClosed;
-            handler?.Invoke(this, new ActionBarDrawerEventArgs(drawerView));
+            DrawerClosed?.Invoke(this, new ActionBarDrawerEventArgs(drawerView));
 
             base.OnDrawerClosed(drawerView);
         }
 
         public override void OnDrawerOpened(View drawerView)
         {
-            var handler = DrawerOpened;
-            handler?.Invoke(this, new ActionBarDrawerEventArgs(drawerView));
+            DrawerOpened?.Invoke(this, new ActionBarDrawerEventArgs(drawerView));
 
             base.OnDrawerOpened(drawerView);
         }
 
         public override void OnDrawerSlide(View drawerView, float slideOffset)
         {
-            var handler = DrawerSlide;
-            handler?.Invoke(this, new ActionBarDrawerSlideEventArgs(drawerView, slideOffset));
+            DrawerSlide?.Invoke(this, new ActionBarDrawerSlideEventArgs(drawerView, slideOffset));
 
             base.OnDrawerSlide(drawerView, slideOffset);
         }
 
         public override void OnDrawerStateChanged(int newState)
         {
-            var handler = DrawerStateChanged;
-            handler?.Invoke(this, new ActionBarDrawerStateChangeEventArgs(newState));
+            DrawerStateChanged?.Invoke(this, new ActionBarDrawerStateChangeEventArgs(newState));
 
             base.OnDrawerStateChanged(newState);
         }

--- a/MvvmCross.Droid.Support.V7.AppCompat/Widget/MvxAppCompatAutoCompleteTextView.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/Widget/MvxAppCompatAutoCompleteTextView.cs
@@ -134,8 +134,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.Widget
 
         private void FireChanged(EventHandler eventHandler)
         {
-            var handler = eventHandler;
-            handler?.Invoke(this, EventArgs.Empty);
+            eventHandler?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -242,8 +242,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
         private void RaiseDataSetChanged()
         {
-            var handler = DataSetChanged;
-            handler?.Invoke(this, EventArgs.Empty);
+            DataSetChanged?.Invoke(this, EventArgs.Empty);
         }
         
         private void NotifyAndRaiseDataSetChanged()


### PR DESCRIPTION
 '?.' is thread safe for event handlers and makes a copy of the initial reference if not-null.  Thus

`handler?.Invoke(...);`

is the equivalent of:

```
var h = handler;
if (h != null)
    h.Invoke(...);
```
