### PR TITLE
Raise AttachCalled with the passed in activity, not this.Activity

### DIFF
--- a/MvvmCross.Droid.Support.Design/EventSource/MvxEventSourceBottomSheetDialogFragment.cs
+++ b/MvvmCross.Droid.Support.Design/EventSource/MvxEventSourceBottomSheetDialogFragment.cs
@@ -57,7 +57,7 @@ namespace MvvmCross.Droid.Support.Design.EventSource
 
 		public override void OnAttach(Activity activity)
 		{
-			AttachCalled.Raise(this, Activity);
+			AttachCalled.Raise(this, activity);
 			base.OnAttach(activity);
 		}
 

--- a/MvvmCross.Droid.Support.V14.Preference/MvxEventSourcePreferenceFragment.cs
+++ b/MvvmCross.Droid.Support.V14.Preference/MvxEventSourcePreferenceFragment.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.Droid.Support.V14.Preference
 
 		public override void OnAttach(Activity activity)
 		{
-			AttachCalled.Raise(this, Activity);
+			AttachCalled.Raise(this, activity);
 			base.OnAttach(activity);
 		}
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceBrowseSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceBrowseSupportFragment.cs
@@ -51,7 +51,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceDetailsSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceDetailsSupportFragment.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceGuidedStepSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceGuidedStepSupportFragment.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceHeadersSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceHeadersSupportFragment.cs
@@ -51,7 +51,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourcePlaybackOverlaySupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourcePlaybackOverlaySupportFragment.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceRowsSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceRowsSupportFragment.cs
@@ -53,7 +53,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceSearchSupportFragment.cs
+++ b/MvvmCross.Droid.Support.V17.Leanback/Fragments/EventSource/MvxEventSourceSearchSupportFragment.cs
@@ -51,7 +51,7 @@ namespace MvvmCross.Droid.Support.V17.Leanback.Fragments.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V4/EventSource/MvxEventSourceDialogFragment.cs
+++ b/MvvmCross.Droid.Support.V4/EventSource/MvxEventSourceDialogFragment.cs
@@ -57,7 +57,7 @@ namespace MvvmCross.Droid.Support.V4.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V4/EventSource/MvxEventSourceFragment.cs
+++ b/MvvmCross.Droid.Support.V4/EventSource/MvxEventSourceFragment.cs
@@ -58,7 +58,7 @@ namespace MvvmCross.Droid.Support.V4.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V4/EventSource/MvxEventSourceListFragment.cs
+++ b/MvvmCross.Droid.Support.V4/EventSource/MvxEventSourceListFragment.cs
@@ -57,7 +57,7 @@ namespace MvvmCross.Droid.Support.V4.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V7.AppCompat/EventSource/MvxEventSourceAppCompatDialogFragment.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/EventSource/MvxEventSourceAppCompatDialogFragment.cs
@@ -57,7 +57,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat.EventSource
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 

--- a/MvvmCross.Droid.Support.V7.Preference/MvxEventSourcePreferenceFragmentCompat.cs
+++ b/MvvmCross.Droid.Support.V7.Preference/MvxEventSourcePreferenceFragmentCompat.cs
@@ -43,7 +43,7 @@ namespace MvvmCross.Droid.Support.V7.Preference
 
         public override void OnAttach(Activity activity)
         {
-            AttachCalled.Raise(this, Activity);
+            AttachCalled.Raise(this, activity);
             base.OnAttach(activity);
         }
 


### PR DESCRIPTION
This shouldn't matter since both should be the host Activity
but changes in the support library could make a difference.

Relevant java for v4's fragment class:

```
/**
 * Return the {@link FragmentActivity} this fragment is currently associated with.
 * May return {@code null} if the fragment is associated with a {@link Context}
 * instead.
 */
final public FragmentActivity getActivity() {
    return mHost == null ? null : (FragmentActivity) mHost.getActivity();
}

/**
 * Called when a fragment is first attached to its context.
 * {@link #onCreate(Bundle)} will be called after this.
 */
public void onAttach(Context context) {
    mCalled = true;
    final Activity hostActivity = mHost == null ? null : mHost.getActivity();
    if (hostActivity != null) {
        mCalled = false;
        onAttach(hostActivity);
    }
}
```
