### PR TITLE
Move displaying fragment out of request from OnCreate to OnNewIntent

### DIFF
--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -349,27 +349,33 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             return mvxFragmentView.UniqueImmutableCacheTag;
         }
 
-	protected override void OnCreate (Bundle bundle)
-	{
-		// Prevents crash when activity in background with history enable is reopened after 
-        	// Android does some auto memory management.
-        	var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(this);
-        	setup.EnsureInitialized();
+	    protected override void OnCreate (Bundle bundle)
+	    {
+		    // Prevents crash when activity in background with history enable is reopened after 
+        	    // Android does some auto memory management.
+        	    var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(this);
+        	    setup.EnsureInitialized();
             
-		base.OnCreate (bundle);
+		    base.OnCreate (bundle);
 
-		if (bundle == null) {
-			var fragmentRequestText = Intent.Extras?.GetString (ViewModelRequestBundleKey);
-			if (fragmentRequestText == null)
-				return;
+		    if (bundle == null)
+		        OnNewIntent(Intent);
+	    }
 
-			var converter = Mvx.Resolve<IMvxNavigationSerializer> ();
-			var fragmentRequest = converter.Serializer.DeserializeObject<MvxViewModelRequest> (fragmentRequestText);
+        protected override void OnNewIntent(Intent intent)
+        {
+            base.OnNewIntent(intent);
 
-			var mvxAndroidViewPresenter = Mvx.Resolve<IMvxAndroidViewPresenter> ();
-			mvxAndroidViewPresenter.Show (fragmentRequest);
-		}
-	}
+            var fragmentRequestText = intent.Extras?.GetString(ViewModelRequestBundleKey);
+            if (fragmentRequestText == null)
+                return;
+
+            var converter = Mvx.Resolve<IMvxNavigationSerializer>();
+            var fragmentRequest = converter.Serializer.DeserializeObject<MvxViewModelRequest>(fragmentRequestText);
+
+            var mvxAndroidViewPresenter = Mvx.Resolve<IMvxAndroidViewPresenter>();
+            mvxAndroidViewPresenter.Show(fragmentRequest);
+        }
 
         /// <summary>
         /// Close Fragment with a specific tag at a specific placeholder

--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -352,20 +352,25 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
 	    protected override void OnCreate (Bundle bundle)
 	    {
 		    // Prevents crash when activity in background with history enable is reopened after 
-        	    // Android does some auto memory management.
-        	    var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(this);
-        	    setup.EnsureInitialized();
+        	// Android does some auto memory management.
+        	var setup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(this);
+        	setup.EnsureInitialized();
             
 		    base.OnCreate (bundle);
 
 		    if (bundle == null)
-		        OnNewIntent(Intent);
+                HandleIntent(Intent);
 	    }
 
         protected override void OnNewIntent(Intent intent)
         {
             base.OnNewIntent(intent);
 
+            HandleIntent(intent);
+        }
+
+        protected virtual void HandleIntent(Intent intent)
+        {
             var fragmentRequestText = intent.Extras?.GetString(ViewModelRequestBundleKey);
             if (fragmentRequestText == null)
                 return;


### PR DESCRIPTION
Imagine the Android app is running. 
An instance of MvxCachingFragmentCompatActivity is shown. Let's call it MainActivity. 

`[Activity(Name = "package.MainActivity", LaunchMode = LaunchMode.SingleTask)]`
`public class MainActivity : MvxCachingFragmentCompatActivity<MainViewModel> { ... }`

When a push notification arrives new notification is displayed in notifications area. Click on it leads to SplashScreen, to handle situations when the app is not currently running. This results in calling ShowViewModel<SomeViewModel>(). SomeViewModel has a corresponding fragment SomeView:

`[MvxFragment(typeof(MainViewModel), Resource.Id.content)]`
`[Register("package.SomeView")]`
`public class SomeView : MvxFragment<SomeViewModel> { ... }`

Custom presenter inherited from MvxFragmentsPresenter receives ShowFragment(MvxViewModelRequest request) call. But current activity is SplashScreen, not MainActivity. This situation is perfectly handled in base implementation of MvxFragmentsPresenter which calls ShowActivity when _fragmentHostRegistrationSettings.IsActualHostValid is false. 
Normally this would cause MainActivity.OnCreate to be called and 

```
if (bundle == null) {
    var fragmentRequestText = Intent.Extras?.GetString (ViewModelRequestBundleKey);
    if (fragmentRequestText == null)
        return;

    var converter = Mvx.Resolve<IMvxNavigationSerializer> ();
    var fragmentRequest = converter.Serializer.DeserializeObject<MvxViewModelRequest> (fragmentRequestText);

    var mvxAndroidViewPresenter = Mvx.Resolve<IMvxAndroidViewPresenter> ();
    mvxAndroidViewPresenter.Show (fragmentRequest);
}
```

to be executed in base implementation of MvxCachingFragmentCompatActivity.OnCreate. 

But in case MainActivity has LaunchMode = LaunchMode.SingleTask OnNewIntent is called instead of OnCreate and required fragment is not shown on top of MainActivity. 
The problem can be solved from developer side by adding 

```
protected override void OnNewIntent(Intent intent)
{
    base.OnNewIntent(intent);

    var fragmentRequestText = intent.Extras?.GetString(ViewModelRequestBundleKey);
    if (fragmentRequestText == null)
        return;

    var converter = Mvx.Resolve<IMvxNavigationSerializer>();
    var fragmentRequest = converter.Serializer.DeserializeObject<MvxViewModelRequest>(fragmentRequestText);

    var mvxAndroidViewPresenter = Mvx.Resolve<IMvxAndroidViewPresenter>();
    mvxAndroidViewPresenter.Show(fragmentRequest);
}
```

Better solution would be for MvxCachingFragmentCompatActivity to have this implementation of OnNewIntent and call it from OnCreate.
