### PR TITLE
Rotating with Fragments fails with saved states

### DIFF
--- a/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
+++ b/MvvmCross.Droid.Support.V7.AppCompat/MvxCachingFragmentCompatActivity.cs
@@ -57,7 +57,7 @@ namespace MvvmCross.Droid.Support.V7.AppCompat
             : base(javaReference, transfer)
         {}
 
-        protected override void OnPostCreate(Bundle savedInstanceState)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
             base.OnPostCreate(savedInstanceState);
             if (savedInstanceState == null) return;


### PR DESCRIPTION
Rotating with Fragments that have a saved state will fail. Consider the following: I have a simple `MvxCachingFragmentCompatActivity` With a single `MvxFragment` inside. The Fragments viewmodel will save and restore it's state to an `MvxBundle`.

If I now rotate, the following happens:
- Rotation begin:
  - Fragments viewmodel (vm1) saves the state (state1) to the bundle
  - The Viewmodel is put into the `MvxMultipleViewModelCache` (vm1_state1)
  - The fragment gets destroyed
- Rotation end:
  - A new Fragment gets created
  - The Fragment restores it's viewmodel from the `MvxMultipleViewModelCache` (vm1_state1)
- `MvxCachingFragmentCompatActivity.OnPostCreate` gets called
  - A new viewmodel (vm2) is created and the state (state1) gets restored from the bundle
  - The new viewmodel (vm2_state1) is put into the `MvxMultipleViewModelCache`

Now as you can see, there are now 2 viewmodels at the same time, with only one beeing used. The real problem however occurs, if you rotate a second time, with a different state:
- The Fragments viewmodel has a different state (vm1_state2)
- Rotation begin:
  - Fragments viewmodel (vm1) saves the state (state2) to the bundle
  - The Viewmodel is **not** put into the `MvxMultipleViewModelCache`, because there is already one inside (vm2_state1)
  - The fragment gets destroyed
- Rotation end:
  - A new Fragment gets created
  - The Fragment restores it's viewmodel from the `MvxMultipleViewModelCache` (vm2_state1) **!!!**
- `MvxCachingFragmentCompatActivity.OnPostCreate` gets called
  - A new viewmodel (vm3) is created and the state (state2) gets restored from the bundle
  - The new viewmodel (vm3_state2) is put into the `MvxMultipleViewModelCache`

As you can see, after the second rotation the old state is reused.

There are basically two ways to fix this. I assume the error here is the wrong order: Debugging showed that the fragments get created before the state is restored. This is the origin of this error. Thus, in this pull-request, all I did was to move the code from `OnPostCreate` to `OnCreate`, because this one gets called before fragments are created.

However, you can also change the behavior of the `MvxMultipleViewModelCache` to overwrite existing viewmodels in the cache. This would save the problem too.

Note: If you need a working example, just leave a comment. But there is no complicated setup needed. Just a Fragment with a viewmodel and a changing saved state.
