### PR TITLE
Recyclerview leak fix

### DIFF
--- a/MvvmCross.Droid.Support.V7.RecyclerView/IMvxRecyclerViewHolder.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/IMvxRecyclerViewHolder.cs
@@ -15,5 +15,6 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
         void OnAttachedToWindow();
         void OnDetachedFromWindow();
+        void OnViewRecycled();
     }
 }

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -128,6 +128,14 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             viewHolder.OnDetachedFromWindow();
         }
 
+        public override void OnViewRecycled(Java.Lang.Object holder)
+        {
+            base.OnViewRecycled(holder);
+
+            var viewHolder = (IMvxRecyclerViewHolder)holder;
+            viewHolder.OnViewRecycled();
+        }
+
         public override Android.Support.V7.Widget.RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
         {
             var itemBindingContext = new MvxAndroidBindingContext(parent.Context, _bindingContext.LayoutInflaterHolder);

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -28,8 +28,6 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         : Android.Support.V7.Widget.RecyclerView.Adapter
         , IMvxRecyclerAdapter
     {
-        public event EventHandler DataSetChanged;
-
         private readonly IMvxAndroidBindingContext _bindingContext;
 
         private ICommand _itemClick, _itemLongClick;
@@ -108,7 +106,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
 
                 // since the template selector has changed then let's force the list to redisplay by firing NotifyDataSetChanged()
                 if (_itemsSource != null)
-                    NotifyAndRaiseDataSetChanged();
+                    NotifyDataSetChanged();
             }
         }
 
@@ -200,7 +198,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                 _subscription = newObservable.WeakSubscribe(OnItemsSourceCollectionChanged);
             }
 
-            NotifyAndRaiseDataSetChanged();
+            NotifyDataSetChanged();
         }
 
         protected virtual void OnItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -215,8 +213,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                 switch (e.Action)
                 {
                     case NotifyCollectionChangedAction.Add:
-                        this.NotifyItemRangeInserted(e.NewStartingIndex, e.NewItems.Count);
-                        this.RaiseDataSetChanged();
+                        NotifyItemRangeInserted(e.NewStartingIndex, e.NewItems.Count);
                         break;
                     case NotifyCollectionChangedAction.Move:
                         for (int i = 0; i < e.NewItems.Count; i++)
@@ -224,20 +221,17 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                             var oldItem = e.OldItems[i];
                             var newItem = e.NewItems[i];
 
-                            this.NotifyItemMoved(this.ItemsSource.GetPosition(oldItem), this.ItemsSource.GetPosition(newItem));
-                            this.RaiseDataSetChanged();
+                            NotifyItemMoved(this.ItemsSource.GetPosition(oldItem), this.ItemsSource.GetPosition(newItem));
                         }
                         break;
                     case NotifyCollectionChangedAction.Replace:
-                        this.NotifyItemRangeChanged(e.NewStartingIndex, e.NewItems.Count);
-                        this.RaiseDataSetChanged();
+                        NotifyItemRangeChanged(e.NewStartingIndex, e.NewItems.Count);
                         break;
                     case NotifyCollectionChangedAction.Remove:
-                        this.NotifyItemRangeRemoved(e.OldStartingIndex, e.OldItems.Count);
-                        this.RaiseDataSetChanged();
+                        NotifyItemRangeRemoved(e.OldStartingIndex, e.OldItems.Count);
                         break;
                     case NotifyCollectionChangedAction.Reset:
-                        this.NotifyAndRaiseDataSetChanged();
+                        NotifyDataSetChanged();
                         break;
                 }
             }
@@ -247,17 +241,6 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                     "Exception masked during Adapter RealNotifyDataSetChanged {0}. Are you trying to update your collection from a background task? See http://goo.gl/0nW0L6",
                     exception.ToLongString());
             }
-        }
-
-        private void RaiseDataSetChanged()
-        {
-            DataSetChanged?.Invoke(this, EventArgs.Empty);
-        }
-        
-        private void NotifyAndRaiseDataSetChanged()
-        {
-            this.RaiseDataSetChanged();
-            this.NotifyDataSetChanged();
         }
     }
 }

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
@@ -32,7 +32,15 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         public object DataContext
         {
             get { return _bindingContext.DataContext; }
-            set { _bindingContext.DataContext = value; }
+            set
+            {
+                _bindingContext.DataContext = value;
+
+                // This is just a precaution.  If we've set the DataContext to something
+                // then we don't need to have the old one still cached.
+                if (value != null)
+                    this._cachedDataContext = null;
+            }
         }
 
         public ICommand Click
@@ -117,6 +125,12 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         public void OnDetachedFromWindow()
         {
             _cachedDataContext = DataContext;
+            DataContext = null;
+        }
+
+        public void OnViewRecycled()
+        {
+            _cachedDataContext = null;
             DataContext = null;
         }
 

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerViewHolder.cs
@@ -112,10 +112,6 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             this._bindingContext = context;
         }
 
-        public MvxRecyclerViewHolder(IntPtr handle, JniHandleOwnership transfer)
-            : base(handle, transfer)
-        {}
-
         public void OnAttachedToWindow()
         {
             if (_cachedDataContext != null && DataContext == null)


### PR DESCRIPTION
This is an attempt to fix MvvmCross/MvvmCross#1343.  If a ViewHolder was recycled it would hold onto the old data context and thus the ItemSource for longer than necessary.  A recycled ViewHolder will either shortly be dead or rebound so there is no point in saving the data context during this time.

Also removes JNI constructor per @jonpryor and the unused DataSetChanged event.
