### PR TITLE
Clear bindings on ViewHolders when the RecyclerView is detached.

### DIFF
--- a/MvvmCross.Droid.Support.V7.RecyclerView/IMvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/IMvxRecyclerAdapter.cs
@@ -24,5 +24,8 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
         object GetItem(int position);
 
         int ItemTemplateId { get; set; }
+
+        // Clears bindings associated with the view holders
+        void ClearAllBindings();
     }
 }

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -266,7 +266,7 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             }
         }
 
-        public void ClearAllBindings()
+        public virtual void ClearAllBindings()
         {
             // Only clear bindings if we're attached to at least one RecyclerView.
             // This might be wrong if we're sharing the adapter with multiple RecyclerViews but

--- a/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
+++ b/MvvmCross.Droid.Support.V7.RecyclerView/MvxRecyclerAdapter.cs
@@ -20,6 +20,9 @@ using MvvmCross.Binding.Attributes;
 using MvvmCross.Binding.Droid.BindingContext;
 using MvvmCross.Binding.ExtensionMethods;
 using MvvmCross.Droid.Support.V7.RecyclerView.ItemTemplates;
+using System.Collections.Generic;
+using Android.Support.V7.Widget;
+using MvvmCross.Binding.BindingContext;
 
 namespace MvvmCross.Droid.Support.V7.RecyclerView
 {
@@ -30,12 +33,17 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
     {
         private readonly IMvxAndroidBindingContext _bindingContext;
 
+        // Keep track of all ViewHolders created by this adapter.
+        private readonly List<WeakReference<IMvxRecyclerViewHolder>> _viewHolders = new List<WeakReference<IMvxRecyclerViewHolder>>();
+
         private ICommand _itemClick, _itemLongClick;
         private IEnumerable _itemsSource;
         private IDisposable _subscription;
         private IMvxTemplateSelector _itemTemplateSelector;
 
         protected IMvxAndroidBindingContext BindingContext => _bindingContext;
+
+        int _attachedRecyclerViews;
 
         public MvxRecyclerAdapter() : this(MvxAndroidBindingContextHelpers.Current()) { }
         public MvxRecyclerAdapter(IMvxAndroidBindingContext bindingContext)
@@ -92,7 +100,6 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             get { return _itemsSource; }
             set { SetItemsSource(value); }
         }
-
         
         public virtual IMvxTemplateSelector ItemTemplateSelector
         {
@@ -134,15 +141,31 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
             viewHolder.OnViewRecycled();
         }
 
+        public override void OnAttachedToRecyclerView(Android.Support.V7.Widget.RecyclerView recyclerView)
+        {
+            ++_attachedRecyclerViews;
+            base.OnAttachedToRecyclerView(recyclerView);
+        }
+
+        public override void OnDetachedFromRecyclerView(Android.Support.V7.Widget.RecyclerView recyclerView)
+        {
+            --_attachedRecyclerViews;
+            base.OnDetachedFromRecyclerView(recyclerView);
+        }
+
         public override Android.Support.V7.Widget.RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
         {
             var itemBindingContext = new MvxAndroidBindingContext(parent.Context, _bindingContext.LayoutInflaterHolder);
-
-            return new MvxRecyclerViewHolder(InflateViewForHolder(parent, viewType, itemBindingContext), itemBindingContext)
+            
+            var vh = new MvxRecyclerViewHolder(InflateViewForHolder(parent, viewType, itemBindingContext), itemBindingContext)
             {
                 Click = ItemClick,
                 LongClick = ItemLongClick
             };
+
+            _viewHolders.Add(new WeakReference<IMvxRecyclerViewHolder>(vh));
+
+            return vh;
         }
 
         public override int GetItemViewType(int position)
@@ -240,6 +263,24 @@ namespace MvvmCross.Droid.Support.V7.RecyclerView
                 Mvx.Warning(
                     "Exception masked during Adapter RealNotifyDataSetChanged {0}. Are you trying to update your collection from a background task? See http://goo.gl/0nW0L6",
                     exception.ToLongString());
+            }
+        }
+
+        public void ClearAllBindings()
+        {
+            // Only clear bindings if we're attached to at least one RecyclerView.
+            // This might be wrong if we're sharing the adapter with multiple RecyclerViews but
+            // I haven't hit this case in the wild.  We may need to revisit this if it's a problem.
+            if (_attachedRecyclerViews > 0)
+            {
+                foreach (var vhRef in _viewHolders)
+                {
+                    IMvxRecyclerViewHolder vh;
+                    if (vhRef.TryGetTarget(out vh))
+                        vh.ClearAllBindings();
+                }
+
+                _viewHolders.Clear();
             }
         }
     }


### PR DESCRIPTION
Keep WeakReferences of all ViewHolders created by the adapter.  When the
associated RecyclerView is detached from the window we clear the bindings.
Note that this does not Dispose of the ViewHolder since the Adapter doesn't
really manage the lifetime of the ViewHolder and there is no callback for
when the ViewHolder is destroyed.

Without this we leak target bindings.

Fixes https://github.com/MvvmCross/MvvmCross/issues/1379
